### PR TITLE
Add correlation labels.

### DIFF
--- a/pkg/ref/correlation.go
+++ b/pkg/ref/correlation.go
@@ -1,0 +1,37 @@
+package ref
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+//
+// Labels
+const (
+	// = Application
+	PartOfLabel = "app.kubernetes.io/part-of"
+)
+
+var (
+	// Application identifier included in correlation labels.
+	// **Must set be by the using application.
+	Application = ""
+)
+
+//
+// Build unique correlation label for an object.
+func CorrelationLabel(object v1.Object) (label, uid string) {
+	label = string(object.GetUID())
+	uid = strings.ToLower(ToKind(object))
+	return
+}
+
+//
+// Build correlation labels for an object.
+func CorrelationLabels(object v1.Object) map[string]string {
+	label, uid := CorrelationLabel(object)
+	return map[string]string{
+		PartOfLabel: Application,
+		label:       uid,
+	}
+}


### PR DESCRIPTION
Add support for _Correlation_ labels in `refs`.  The goal is to provide a standard, shared implementation.  The functionality is a bit thin but I _think_ it adds value.

The application will be set in api package init().
```
func init() {
    libref.Application = "virt.migration.openshift.io"
}
```

Example: Used when creating resources.
```
{
    Labels: libref.CorrelationLabels(plan),
}
```
