### PR TITLE
correlation prefix removed.

### DIFF
--- a/pkg/ref/labels.go
+++ b/pkg/ref/labels.go
@@ -13,23 +13,25 @@ const (
 )
 
 var (
-	// Application identifier included in correlation labels.
+	// Application identifier included in reference labels.
 	// **Must set be by the using application.
 	Application = ""
 )
 
 //
-// Build unique correlation label for an object.
-func CorrelationLabel(object v1.Object) (label, uid string) {
+// Build unique reference label for an object.
+// Format: <kind> = <uid>
+func Label(object v1.Object) (label, uid string) {
 	label = string(object.GetUID())
 	uid = strings.ToLower(ToKind(object))
 	return
 }
 
 //
-// Build correlation labels for an object.
-func CorrelationLabels(object v1.Object) map[string]string {
-	label, uid := CorrelationLabel(object)
+// Build reference labels for an object.
+// Includes both `Application` and unique labels.
+func Labels(object v1.Object) map[string]string {
+	label, uid := Label(object)
 	return map[string]string{
 		PartOfLabel: Application,
 		label:       uid,


### PR DESCRIPTION
Support for _correlation_ labels was added in the ref package because they are a form or reference.  The label is really a _reference label_ that is most commonly used for correlation.  It's important to name things for what they are and not what they're used for.  Since everything in Go is package-qualified, the _Correlation_ prefix should be removed.

Results (example) usage:
```
   ref.Labels(plan)
```