### PR TITLE
Add LibError and return wrapped error instead of logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # controller
 Common controller lib.  Provides components shared by application controllers.
+
+Requires: Go 1.13+

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,18 +1,3 @@
 package pkg
 
-import (
-	"github.com/konveyor/controller/pkg/inventory/container"
-	"github.com/konveyor/controller/pkg/inventory/model"
-	"github.com/konveyor/controller/pkg/inventory/web"
-	"github.com/konveyor/controller/pkg/logging"
-)
-
 //go:generate go run ../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../hack/boilerplate.go.txt
-
-//
-// Set loggers.
-func SetLogger(logger *logging.Logger) {
-	container.Log = logger
-	model.Log = logger
-	web.Log = logger
-}

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -1,0 +1,26 @@
+package error
+
+import (
+	"errors"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	err := errors.New("failed")
+	le := Wrap(err).(*Error)
+	g.Expect(le).NotTo(gomega.BeNil())
+	g.Expect(le.wrapped).To(gomega.Equal(err))
+	g.Expect(len(le.stack)).To(gomega.Equal(4))
+	g.Expect(le.Error()).To(gomega.Equal(err.Error()))
+
+	le2 := Wrap(err).(*Error)
+	g.Expect(le2).NotTo(gomega.BeNil())
+	g.Expect(le2.wrapped).To(gomega.Equal(err))
+	g.Expect(len(le2.stack)).To(gomega.Equal(4))
+	g.Expect(le2.Error()).To(gomega.Equal(err.Error()))
+
+	println(le.Stack())
+}

--- a/pkg/error/wrap.go
+++ b/pkg/error/wrap.go
@@ -1,0 +1,81 @@
+package error
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+//
+// Create a new wrapped error.
+func New(m string) error {
+	return Wrap(errors.New(m))
+}
+
+//
+// Wrap an error.
+// Returns `err` when err is `nil` or *Error.
+func Wrap(err error) error {
+	if err == nil {
+		return err
+	}
+	if le, cast := err.(*Error); cast {
+		return le
+	}
+	bfr := make([]uintptr, 50)
+	n := runtime.Callers(2, bfr[:])
+	frames := runtime.CallersFrames(bfr[:n])
+	stack := []string{""}
+	for {
+		f, hasNext := frames.Next()
+		frame := fmt.Sprintf(
+			"%s()\n\t%s:%d",
+			f.Function,
+			f.File,
+			f.Line)
+		stack = append(stack, frame)
+		if !hasNext {
+			break
+		}
+	}
+	return &Error{
+		stack:   stack,
+		wrapped: err,
+	}
+}
+
+//
+// Error.
+// Wraps a root cause error and captures
+// the stack.
+type Error struct {
+	// Original error.
+	wrapped error
+	// Stack.
+	stack []string
+}
+
+//
+// Error description.
+func (e Error) Error() string {
+	return e.wrapped.Error()
+}
+
+//
+// Error stack trace.
+// Format:
+//   package.Function()
+//     file:line
+//   package.Function()
+//     file:line
+//   ...
+func (e Error) Stack() string {
+	return strings.Join(e.stack, "\n")
+}
+
+//
+// Unwrap the error.
+func (e Error) Unwrap() error {
+	return e.wrapped
+}

--- a/pkg/inventory/container/container.go
+++ b/pkg/inventory/container/container.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/controller/pkg/inventory/model"
 	"github.com/konveyor/controller/pkg/ref"
 	core "k8s.io/api/core/v1"
@@ -44,11 +45,8 @@ func (c *Container) Add(object meta.Object, reconciler Reconciler) error {
 	if err != nil {
 		delete(c.content, key)
 		reconciler.Shutdown(false)
-		Log.Trace(err)
-		return err
+		return liberr.Wrap(err)
 	}
-
-	Log.Info("Reconciler added.", "name", reconciler.Name())
 
 	return nil
 }
@@ -60,7 +58,6 @@ func (c *Container) Delete(object meta.Object) {
 	defer c.mutex.Unlock()
 	key := c.key(object)
 	if r, found := c.content[key]; found {
-		Log.Info("Reconciler deleted.", "name", r.Name())
 		delete(c.content, key)
 		r.Shutdown(true)
 	}

--- a/pkg/inventory/container/doc.go
+++ b/pkg/inventory/container/doc.go
@@ -5,18 +5,6 @@
 //
 package container
 
-import (
-	"github.com/konveyor/controller/pkg/logging"
-)
-
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("container")
-	log.Reset()
-	Log = &log
-}
-
 //
 // Build a new container.
 func New() *Container {

--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -1,15 +1,5 @@
 package model
 
-import "github.com/konveyor/controller/pkg/logging"
-
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("model")
-	log.Reset()
-	Log = &log
-}
-
 //
 // New database.
 func New(path string, models ...interface{}) DB {

--- a/pkg/inventory/model/model.go
+++ b/pkg/inventory/model/model.go
@@ -7,11 +7,10 @@ import (
 	"reflect"
 )
 
-// Not found error.
-var NotFound = sql.ErrNoRows
-
-// Conflict error.
+//
+// Errors.
 var Conflict = errors.New("conflict")
+var NotFound = sql.ErrNoRows
 
 //
 // Database client interface.

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"github.com/onsi/gomega"
 	"math"
@@ -62,7 +63,7 @@ func TestModels(t *testing.T) {
 	err = DB.Update(thing)
 	g.Expect(err).To(gomega.BeNil())
 	err = DB.Update(thing)
-	g.Expect(err).To(gomega.Equal(Conflict))
+	g.Expect(errors.Is(err, Conflict)).To(gomega.BeTrue())
 
 	// Test List
 	list := []Thing{}
@@ -78,7 +79,7 @@ func TestModels(t *testing.T) {
 	err = DB.Insert(thing)
 	g.Expect(err).To(gomega.BeNil())
 	err = DB.Get(thing)
-	g.Expect(err).To(gomega.Equal(NotFound))
+	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
 	err = tx.Commit()
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(client.tx).To(gomega.BeNil())
@@ -92,11 +93,11 @@ func TestModels(t *testing.T) {
 	err = DB.Insert(thing)
 	g.Expect(err).To(gomega.BeNil())
 	err = DB.Get(thing)
-	g.Expect(err).To(gomega.Equal(NotFound))
+	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
 	tx.rollback()
 	g.Expect(client.tx).To(gomega.BeNil())
 	err = DB.Get(thing)
-	g.Expect(err).To(gomega.Equal(NotFound))
+	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
 }
 
 //
@@ -134,7 +135,7 @@ func __TestConcurrency(t *testing.T) {
 			go func() {
 				err := DB.Get(m)
 				if err != nil {
-					if err == NotFound {
+					if errors.Is(err, NotFound) {
 						fmt.Printf("read|%d _____%s\n", i, err)
 					} else {
 						panic(err)
@@ -155,7 +156,7 @@ func __TestConcurrency(t *testing.T) {
 			go func() {
 				err := DB.Delete(m)
 				if err != nil {
-					if err == NotFound {
+					if errors.Is(err, NotFound) {
 						fmt.Printf("del|%d _____%s\n", i, err)
 					} else {
 						panic(err)
@@ -176,7 +177,7 @@ func __TestConcurrency(t *testing.T) {
 			go func() {
 				err := DB.Update(m)
 				if err != nil {
-					if err == NotFound {
+					if errors.Is(err, NotFound) {
 						fmt.Printf("update|%d _____%s\n", i, err)
 					} else {
 						panic(err)

--- a/pkg/inventory/web/doc.go
+++ b/pkg/inventory/web/doc.go
@@ -1,11 +1,12 @@
 package web
 
-import "github.com/konveyor/controller/pkg/logging"
+import "github.com/konveyor/controller/pkg/inventory/container"
 
-var Log *logging.Logger
-
-func init() {
-	log := logging.WithName("model")
-	log.Reset()
-	Log = &log
+//
+// Build new web server.
+func New(c *container.Container, routes ...RequestHandler) *WebServer {
+	return &WebServer{
+		Handlers:  routes,
+		Container: c,
+	}
 }

--- a/pkg/inventory/web/handler.go
+++ b/pkg/inventory/web/handler.go
@@ -31,7 +31,6 @@ type Paged struct {
 // Prepare the handler to fulfil the request.
 // Set the `token` and `page` fields using passed parameters.
 func (h *Paged) Prepare(ctx *gin.Context) int {
-	Log.Reset()
 	status := h.setPage(ctx)
 	if status != http.StatusOK {
 		return status

--- a/pkg/inventory/web/web.go
+++ b/pkg/inventory/web/web.go
@@ -27,15 +27,6 @@ type WebServer struct {
 }
 
 //
-// Build new web server.
-func New(c *container.Container, routes ...RequestHandler) *WebServer {
-	return &WebServer{
-		Handlers:  routes,
-		Container: c,
-	}
-}
-
-//
 // Start the web-server.
 // Initializes `gin` with routes and CORS origins.
 func (w *WebServer) Start() {
@@ -59,18 +50,9 @@ func (w *WebServer) buildOrigins() {
 	for _, r := range w.AllowedOrigins {
 		expr, err := regexp.Compile(r)
 		if err != nil {
-			Log.Error(
-				err,
-				"origin not valid",
-				"expr",
-				r)
 			continue
 		}
 		w.allowedOrigins = append(w.allowedOrigins, expr)
-		Log.Info(
-			"Added allowed origin.",
-			"expr",
-			r)
 	}
 }
 
@@ -90,8 +72,6 @@ func (w *WebServer) allow(origin string) bool {
 			return true
 		}
 	}
-
-	Log.Info("Denied.", "origin", origin)
 
 	return false
 }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,100 @@
+package logging
+
+import (
+	"errors"
+	"github.com/go-logr/logr"
+	liberr "github.com/konveyor/controller/pkg/error"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+type entry struct {
+	message string
+	kvpair  []interface{}
+	err     error
+}
+
+type fake struct {
+	entry []entry
+}
+
+func (l *fake) Info(message string, kvpair ...interface{}) {
+	l.entry = append(
+		l.entry,
+		entry{
+			message: message,
+			kvpair:  kvpair,
+		})
+}
+
+func (l *fake) Error(err error, message string, kvpair ...interface{}) {
+	l.entry = append(
+		l.entry,
+		entry{
+			message: message,
+			kvpair:  kvpair,
+			err:     err,
+		})
+}
+
+func (l fake) Enabled() bool {
+	return true
+}
+
+func (l fake) V(level int) logr.InfoLogger {
+	return nil
+}
+
+func (l fake) WithName(name string) logr.Logger {
+	return nil
+}
+
+//
+// Get logger with values.
+func (l fake) WithValues(kvpair ...interface{}) logr.Logger {
+	return nil
+}
+
+func TestLogger(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	//
+	// Real
+	log := WithName("Test")
+	log.Info("hello")
+	log.Error(errors.New("A"), "thing failed")
+	log.Trace(errors.New("B"))
+	//
+	// Faked
+	log.Reset()
+	f := &fake{entry: []entry{}}
+	log.Real = f
+	// Info
+	log.Info("hello")
+	g.Expect(len(f.entry)).To(gomega.Equal(1))
+	g.Expect(len(f.entry[0].kvpair)).To(gomega.Equal(0))
+	g.Expect(log.history[f.entry[0].err]).ToNot(gomega.BeNil())
+	// Error
+	log.Error(errors.New("C"), "thing failed")
+	g.Expect(len(f.entry)).To(gomega.Equal(2))
+	g.Expect(len(f.entry[1].kvpair)).To(gomega.Equal(0))
+	g.Expect(log.history[f.entry[1].err]).ToNot(gomega.BeNil())
+	// Trace
+	log.Trace(errors.New("D"))
+	g.Expect(len(f.entry)).To(gomega.Equal(3))
+	g.Expect(len(f.entry[2].kvpair)).To(gomega.Equal(0))
+	g.Expect(log.history[f.entry[2].err]).ToNot(gomega.BeNil())
+	// Error (wrapped)
+	log.Error(liberr.Wrap(errors.New("C wrapped")), "thing failed")
+	g.Expect(len(f.entry)).To(gomega.Equal(4))
+	g.Expect(len(f.entry[3].kvpair)).To(gomega.Equal(4))
+	g.Expect(f.entry[3].kvpair[0]).To(gomega.Equal(Error))
+	g.Expect(f.entry[3].kvpair[2]).To(gomega.Equal(Stack))
+	g.Expect(log.history[f.entry[3].err]).ToNot(gomega.BeNil())
+	// Trace (wrapped)
+	log.Trace(liberr.Wrap(errors.New("D wrapped")))
+	g.Expect(len(f.entry)).To(gomega.Equal(5))
+	g.Expect(len(f.entry[4].kvpair)).To(gomega.Equal(4))
+	g.Expect(f.entry[4].kvpair[0]).To(gomega.Equal(Error))
+	g.Expect(f.entry[4].kvpair[2]).To(gomega.Equal(Stack))
+	g.Expect(log.history[f.entry[4].err]).ToNot(gomega.BeNil())
+}


### PR DESCRIPTION
Add `Error` and return _wrapped_ error instead of logging in all packages.
The inventory packages migration from MIG were logging error with log.Trace().  The initial thinking what that the _Logger_ for these packages could be set by the controller using them.  However, since the packages could be used in multiple contexts and goroutines, this isn't really a good idea.  To ensure that errors raised (created and returned) from the lib packages can be logged once with the original stack trace, this PR introduces _wrapping_.  Instead of a policy of trace-and-return, the policy will be wrap-and-return.  This introduces the unwanted complexities of error wrapping but I think it's worth it.  Mainly, that a type assertion or equality comparison is more complicated.  The wrapped error must be _unwrapped_ before it can be compared.  This should have a minor impact since most of our code does not _inspect_ errors.  The `Unwrap()` method will support nice features in Go 1.13.  Mainly `errors.Is()` and `errors.As()`.