### PR TITLE
Add reconciler owner; support all intX types in model.

### DIFF
--- a/pkg/inventory/container/container.go
+++ b/pkg/inventory/container/container.go
@@ -24,19 +24,19 @@ type Container struct {
 
 //
 // Get a reconciler by (CR) object.
-func (c *Container) Get(object meta.Object) (Reconciler, bool) {
+func (c *Container) Get(owner meta.Object) (Reconciler, bool) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	p, found := c.content[c.key(object)]
+	p, found := c.content[c.key(owner)]
 	return p, found
 }
 
 //
 // Add a reconciler.
-func (c *Container) Add(object meta.Object, reconciler Reconciler) error {
+func (c *Container) Add(reconciler Reconciler) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	key := c.key(object)
+	key := c.key(reconciler.Owner())
 	if current, found := c.content[key]; found {
 		current.Shutdown(false)
 	}
@@ -53,10 +53,10 @@ func (c *Container) Add(object meta.Object, reconciler Reconciler) error {
 
 //
 // Delete the reconciler.
-func (c *Container) Delete(object meta.Object) {
+func (c *Container) Delete(owner meta.Object) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	key := c.key(object)
+	key := c.key(owner)
 	if r, found := c.content[key]; found {
 		delete(c.content, key)
 		r.Shutdown(true)
@@ -65,11 +65,11 @@ func (c *Container) Delete(object meta.Object) {
 
 //
 // Build a reconciler key for an object.
-func (*Container) key(object meta.Object) Key {
+func (*Container) key(owner meta.Object) Key {
 	return Key{
-		Kind:      ref.ToKind(object),
-		Namespace: object.GetNamespace(),
-		Name:      object.GetName(),
+		Kind:      ref.ToKind(owner),
+		Namespace: owner.GetNamespace(),
+		Name:      owner.GetName(),
 	}
 }
 
@@ -78,6 +78,8 @@ func (*Container) key(object meta.Object) Key {
 type Reconciler interface {
 	// The name.
 	Name() string
+	// The resource that owns the reconciler.
+	Owner() meta.Object
 	// Start the reconciler.
 	Start() error
 	// Shutdown the reconciler.

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -14,6 +14,9 @@ type Thing struct {
 	ID       int    `sql:"key"`
 	Name     string `sql:"key"`
 	Revision int64  `sql:"revision"`
+	Int8     int8   `sql:"int8"`
+	Int16    int16  `sql:"int16"`
+	Int32    int32  `sql:"int32"`
 	labels   Labels
 }
 

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -458,6 +458,9 @@ func (t Table) Fields(model interface{}) ([]*Field, error) {
 					Value: &fv,
 				})
 		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
 			reflect.Int64:
 			fields = append(
 				fields,
@@ -769,6 +772,9 @@ func (f *Field) Validate() error {
 			return liberr.Wrap(err)
 		}
 	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
 		reflect.Int64:
 	default:
 		err := errors.New("must be: (string, int)")
@@ -788,6 +794,9 @@ func (f *Field) Pull() interface{} {
 		f.string = f.Value.String()
 		return f.string
 	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
 		reflect.Int64:
 		f.int = f.Value.Int()
 		return f.int
@@ -803,6 +812,9 @@ func (f *Field) Ptr() interface{} {
 	case reflect.String:
 		return &f.string
 	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
 		reflect.Int64:
 		return &f.int
 	}
@@ -818,6 +830,9 @@ func (f *Field) Push() {
 	case reflect.String:
 		f.Value.SetString(f.string)
 	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
 		reflect.Int64:
 		f.Value.SetInt(f.int)
 	}
@@ -835,6 +850,9 @@ func (f *Field) DDL() string {
 	case reflect.String:
 		part[1] = "TEXT"
 	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
 		reflect.Int64:
 		part[1] = "INTEGER"
 	}
@@ -862,6 +880,9 @@ func (f *Field) Empty() bool {
 	case reflect.String:
 		return len(f.string) == 0
 	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
 		reflect.Int64:
 		return f.int == 0
 	}


### PR DESCRIPTION
Two changes needed for virt.
1. Add `Reconciler.Owner()` so that the associated CR for the thing being reconciled is available.  In the case of virt, I need the `Provider`.
2. Add support for other integer types in the model.