### PR TITLE
Event

### DIFF
--- a/pkg/inventory/model/journal.go
+++ b/pkg/inventory/model/journal.go
@@ -1,0 +1,289 @@
+package model
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	"github.com/konveyor/controller/pkg/ref"
+	"reflect"
+	"sync"
+)
+
+//
+// Event Actions.
+var (
+	Created int8 = 0x01
+	Updated int8 = 0x02
+	Deleted int8 = 0x04
+)
+
+//
+// Model event.
+type Event struct {
+	// The event subject.
+	Model Model
+	// The event action (created|updated|deleted).
+	Action int8
+}
+
+//
+// Event handler.
+type EventHandler interface {
+	// A model has been created.
+	Created(Model)
+	// A model has been updated.
+	Updated(Model)
+	// A model has been deleted.
+	Deleted(Model)
+	// An error has occurred delivering an event.
+	Error(error)
+	// An event watch has ended.
+	End()
+}
+
+//
+// Model event watch.
+type Watch struct {
+	// Model to be watched.
+	Model Model
+	// Event handler.
+	Handler EventHandler
+	// Event queue.
+	queue chan *Event
+	// Started
+	started bool
+}
+
+//
+// Match by model `kind`.
+func (w *Watch) Match(model Model) bool {
+	return ref.ToKind(w.Model) == ref.ToKind(model)
+}
+
+//
+// Queue event.
+func (w *Watch) notify(event *Event) {
+	if !w.Match(event.Model) {
+		return
+	}
+	defer func() {
+		recover()
+	}()
+	select {
+	case w.queue <- event:
+	default:
+		err := liberr.New("full queue, event discarded")
+		w.Handler.Error(err)
+	}
+}
+
+//
+// Run the watch.
+// Forward events to the `handler`.
+func (w *Watch) Start() {
+	if w.started {
+		return
+	}
+	run := func() {
+		for event := range w.queue {
+			switch event.Action {
+			case Created:
+				w.Handler.Created(event.Model)
+			case Updated:
+				w.Handler.Updated(event.Model)
+			case Deleted:
+				w.Handler.Deleted(event.Model)
+			default:
+				w.Handler.Error(liberr.New("unknown action"))
+			}
+		}
+		w.Handler.End()
+	}
+
+	w.started = true
+	go run()
+}
+
+//
+// End the watch.
+func (w *Watch) End() {
+	close(w.queue)
+}
+
+//
+// Event manager.
+type Journal struct {
+	*Client
+	mutex sync.RWMutex
+	// List of registered watches.
+	watches []*Watch
+	// Queue of staged events.
+	staged []*Event
+	// Enabled.
+	enabled bool
+}
+
+//
+// The journal is enabled.
+// Must be enabled for watch models.
+func (r *Journal) Enabled() bool {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	return r.enabled
+}
+
+//
+// Enable the journal.
+func (r *Journal) Enable() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.enabled = true
+}
+
+//
+// Disable the journal.
+// End all watches and discard staged events.
+func (r *Journal) Disable() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	for _, w := range r.watches {
+		w.End()
+	}
+	r.watches = []*Watch{}
+	r.staged = []*Event{}
+	r.enabled = false
+}
+
+//
+// Watch a `watch` of the specified model.
+// The returned watch has not been started.
+// See: Watch.Start().
+func (r *Journal) Watch(model Model, handler EventHandler) (*Watch, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.enabled {
+		return nil, liberr.New("disabled")
+	}
+	watch := &Watch{
+		Handler: handler,
+		Model:   model,
+	}
+	r.watches = append(r.watches, watch)
+	watch.queue = make(chan *Event, 10000)
+	return watch, nil
+}
+
+//
+// End watch.
+func (r *Journal) End(watch *Watch) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.enabled {
+		return
+	}
+	kept := []*Watch{}
+	for _, w := range r.watches {
+		if w != watch {
+			kept = append(kept, w)
+			continue
+		}
+		w.End()
+	}
+
+	r.watches = kept
+}
+
+//
+// A model has been created.
+// Queue an event.
+func (r *Journal) Created(model Model) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.enabled {
+		return
+	}
+	r.staged = append(
+		r.staged,
+		&Event{
+			Model:  r.snapshot(model),
+			Action: Created,
+		})
+}
+
+//
+// A model has been updated.
+// Queue an event.
+func (r *Journal) Updated(model Model) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.enabled {
+		return
+	}
+	r.staged = append(
+		r.staged,
+		&Event{
+			Model:  r.snapshot(model),
+			Action: Updated,
+		})
+}
+
+//
+// A model has been deleted.
+// Queue an event.
+func (r *Journal) Deleted(model Model) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.enabled {
+		return
+	}
+	r.staged = append(
+		r.staged,
+		&Event{
+			Model:  r.snapshot(model),
+			Action: Deleted,
+		})
+}
+
+//
+// Commit staged events and notify handlers.
+func (r *Journal) Commit() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.enabled {
+		return
+	}
+	for _, event := range r.staged {
+		for _, w := range r.watches {
+			w.notify(event)
+		}
+	}
+
+	r.staged = []*Event{}
+}
+
+//
+// Discard staged events.
+func (r *Journal) Unstage() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.enabled {
+		return
+	}
+
+	r.staged = []*Event{}
+}
+
+//
+// Create a snapshot of the model.
+// The model is a pointer must be protected against being
+// changed at it origin or by the handlers.
+func (r *Journal) snapshot(model Model) Model {
+	mt := reflect.TypeOf(model)
+	mv := reflect.ValueOf(model)
+	switch mt.Kind() {
+	case reflect.Ptr:
+		mt = mt.Elem()
+		mv = mv.Elem()
+	}
+	new := reflect.New(mt).Elem()
+	new.Set(mv)
+	return new.Addr().Interface().(Model)
+}

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -29,7 +29,10 @@ func (m *Thing) SetPk() {
 }
 
 func (m *Thing) String() string {
-	return m.Name
+	return fmt.Sprintf(
+		"Thing: id: %d, name:%s",
+		m.ID,
+		m.Name)
 }
 
 func (m *Thing) Equals(other Model) bool {
@@ -40,21 +43,64 @@ func (m *Thing) Labels() Labels {
 	return m.labels
 }
 
+type TestHandler struct {
+	name    string
+	created []int
+	updated []int
+	deleted []int
+	err     []error
+	done    bool
+}
+
+func (w *TestHandler) Created(model Model) {
+	if thing, cast := model.(*Thing); cast {
+		w.created = append(w.created, thing.ID)
+	}
+}
+
+func (w *TestHandler) Updated(model Model) {
+	if thing, cast := model.(*Thing); cast {
+		w.updated = append(w.updated, thing.ID)
+	}
+}
+func (w *TestHandler) Deleted(model Model) {
+	if thing, cast := model.(*Thing); cast {
+		w.deleted = append(w.deleted, thing.ID)
+	}
+}
+
+func (w *TestHandler) Error(err error) {
+	w.err = append(w.err, err)
+}
+
+func (w *TestHandler) End() {
+}
+
 func TestModels(t *testing.T) {
 	var err error
+
+	g := gomega.NewGomegaWithT(t)
+
+	// Build the DB.
 	DB := New(
 		"/tmp/test.db",
 		&Label{},
 		&Thing{})
-	DB.Open(true)
-	client := DB.(*Client)
-
-	g := gomega.NewGomegaWithT(t)
+	err = DB.Open(true)
 	g.Expect(err).To(gomega.BeNil())
-	g.Expect(client.db).ToNot(gomega.BeNil())
+	g.Expect(DB.(*Client).db).ToNot(gomega.BeNil())
 
+	// Test create handler.
+	DB.Journal().Enable()
+	handlerA := &TestHandler{name: "A"}
+	watchA, err := DB.Watch(&Thing{}, handlerA)
+	g.Expect(watchA).ToNot(gomega.BeNil())
+	g.Expect(err).To(gomega.BeNil())
+
+	// Create a model.
 	thing := &Thing{
-		ID: 0,
+		ID:   0,
+		Name: "Elmer",
 		labels: Labels{
 			"role": "main",
 		},
@@ -107,18 +153,18 @@ func TestModels(t *testing.T) {
 	thing.ID = 1
 	tx, err := DB.Begin()
 	g.Expect(err).To(gomega.BeNil())
-	g.Expect(tx.ref).To(gomega.Equal(client.tx))
+	g.Expect(tx.ref).To(gomega.Equal(DB.(*Client).tx))
 	err = DB.Insert(thing)
 	g.Expect(err).To(gomega.BeNil())
 	err = DB.Get(thing)
 	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
 	err = tx.Commit()
 	g.Expect(err).To(gomega.BeNil())
-	g.Expect(client.tx).To(gomega.BeNil())
+	g.Expect(DB.(*Client).tx).To(gomega.BeNil())
 	err = DB.Get(thing)
 	g.Expect(err).To(gomega.BeNil())
 
-	// Test Tx - rellback
+	// Test Tx - rollback
 	thing.ID = 2
 	tx, err = DB.Begin()
 	g.Expect(err).To(gomega.BeNil())
@@ -126,10 +172,42 @@ func TestModels(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 	err = DB.Get(thing)
 	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
-	tx.rollback()
-	g.Expect(client.tx).To(gomega.BeNil())
+	tx.End()
+	g.Expect(DB.(*Client).tx).To(gomega.BeNil())
 	err = DB.Get(thing)
 	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
+
+	handlerB := &TestHandler{name: "B"}
+	watchB, err := DB.Watch(&Thing{}, handlerB)
+	g.Expect(watchB).ToNot(gomega.BeNil())
+	g.Expect(err).To(gomega.BeNil())
+
+	created := []int{0, 1}
+	updated := []int{0, 0}
+	for i := 2; i < 100; i++ {
+		created = append(created, i)
+		thing.ID = i
+		err = DB.Insert(thing)
+		g.Expect(err).To(gomega.BeNil())
+	}
+
+	for i := 0; i < 10; i++ {
+		time.Sleep(time.Second)
+		if len(handlerA.created) != len(created) ||
+			len(handlerA.updated) != len(updated) ||
+			len(handlerB.created) != len(created) {
+			continue
+		} else {
+			break
+		}
+	}
+
+	g.Expect(handlerA.created).To(
+		gomega.Equal(created))
+	g.Expect(handlerA.updated).To(
+		gomega.Equal(updated))
+	g.Expect(handlerB.created).To(
+		gomega.Equal(created))
 }
 
 //


### PR DESCRIPTION
Add model event watch/notifications.  For MTV this will be useful for driving integration with Migration Analytics (MA) in the form of annotating VMs when the model is updated.  And, optionally by layering `watch` capability in the API (much like the kubernetes API server).  This may also be needed for triggering reconciles of the plan controller when the provider inventory changes.

The design is inspired by _kubernetes_ and is as follows:

A _(new)_  `Journal` is associated with the DB client.  The journal is notified of changes to the model which it forwards to each registered `Watch`. A `Watch` is registered for a model and a (target) `EventHandler` and is a _worker_ running a _goroutine_ that consumes (reads) events from its channel.  Each event is forwarded to the asscoiated handler.

**Note:** The journal is disabled by default.

```
Client.Insert() -> Journal  -> |-> Watch -> EventHandler.Created()
                               |-> Watch -> EventHandler.Created()
                               |-> Watch -> EventHandler.Created()
```

Example with a `Thing` model:
```
type TestHandler struct {
}

func (w *TestHandler) Created(model Model) {
	if thing, cast := model.(*Thing); cast {
		// do something
	}
}

func (w *TestHandler) Updated(model Model) {
	if thing, cast := model.(*Thing); cast {
		// do something
	}
}
func (w *TestHandler) Deleted(model Model) {
	if thing, cast := model.(*Thing); cast {
		// do something
	}
}

func (w *TestHandler) Error(err error) {
	// do something
}

func (w *TestHandler) End() {
    // do something
}

DB.Watch(&Thing{}, &TestHandler{})
```
