### PR TITLE
Model enhancements.

### DIFF
--- a/pkg/inventory/container/container.go
+++ b/pkg/inventory/container/container.go
@@ -32,6 +32,19 @@ func (c *Container) Get(owner meta.Object) (Reconciler, bool) {
 }
 
 //
+// List all reconcilers.
+func (c *Container) List() []Reconciler {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	list := []Reconciler{}
+	for _, r := range c.content {
+		list = append(list, r)
+	}
+
+	return list
+}
+
+//
 // Add a reconciler.
 func (c *Container) Add(reconciler Reconciler) error {
 	c.mutex.Lock()

--- a/pkg/inventory/container/doc.go
+++ b/pkg/inventory/container/doc.go
@@ -3,6 +3,10 @@
 //   |__Reconciler
 //   |__Reconciler
 //
+// The container is a collection of data model reconcilers.
+// Each reconciler is responsible for ensuring that changes made
+// to the external data source are reflected in the DB.  The
+// goal is for the data model to be eventually consistent.
 package container
 
 //

--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -1,3 +1,104 @@
+// The `model` package essentially provides a lightweight object
+// relational model (ORM) based on sqlite3 intended to support the
+// needs of the `container` package.
+// Each entity (table) is modeled by a struct.  Each field (column)
+// is described using tags:
+//   `sql:"pk"`
+//       The primary key.
+//   `sql:"key"`
+//       The field is part of the natural key.
+//   `sql:"fk:T(F)"`
+//       Foreign key `T` = model type, `F` = model field.
+//   `sql:"unique(G)"`
+//       Unique index. `G` = unique-together fields.
+//   `sql:"const"`
+//       The field is immutable and not included on update.
+// Each struct must implement the `Model` interface.
+// Basic CRUD operations may be performed on each model using
+// the `DB` interface which together with the `Model` interface
+// provides value-added features and optimizations.
+//
+// Examples:
+//
+// Define a model.
+//   type Person struct {
+//       ID    string `sql:"pk"`
+//       First string `sql:"key"`
+//       Last  string `sql:"key"
+//       Age   int    `sql:""`
+//   }
+//
+//   func (p *Person) Pk() string {...}
+//   func (p *Person) Equals(other Model) bool {...}
+//   func (p *Person) Labels() {...}
+//   func (p *Person) String() string {...}
+//
+// Insert the model:
+//   person := &Person{
+//       First: "Elmer",
+//       Last:  "Fudd",
+//       Age: 55,
+//   }
+//
+//   err := DB.Insert(person)
+//
+// In the event the primary key (PK) field is not populated,
+// the DB will derive (generate) its value as a sha1 of the
+// natural key fields.
+//
+// Update the model:
+//   person.Age = 62
+//   err := DB.Update(person)
+//
+// Delete the model by natural key:
+//   person := &Person{
+//       First: "Elmer",
+//       Last:  "Fudd",
+//   }
+//
+//   err := DB.Delete(person)
+//
+// Get (fetch) a single model by natural key.
+// This will populate the fields with data from the DB.
+//   person := &Person{
+//       First: "Elmer",
+//       Last:  "Fudd",
+//   }
+//
+//  err := DB.Get(person)
+//
+// List (fetch) all models.
+//   persons := []Person{}
+//   err := DB.List(&persons, ListOptions{})
+//
+// List (fetch) specific models.
+// The `ListOptions` may be used to qualify or paginate the
+// List() result set.  All predicates may be combined.
+//
+// Count (only):
+//   err := DB.List(&persons, ListOptions{Count: true})
+//
+// Paginate the result:
+//   err := DB.List(
+//       &persons,
+//       ListOptions{
+//           Page: {
+//               Offset: 3, // page 3.
+//               Limit: 10, // 10 models per page.
+//           },
+//       })
+//
+// List specific models.
+// List persons with the last name of "Fudd" and legal to vote.
+//   err := DB.List(
+//       &persons,
+//       ListOptions{
+//           Predicate: And(
+//               Eq("Name", "Fudd"),
+//               Gt("Age": 17),
+//           },
+//       })
+//
 package model
 
 //

--- a/pkg/inventory/model/label.go
+++ b/pkg/inventory/model/label.go
@@ -1,10 +1,39 @@
 package model
 
+//
+// Labels collection.
 type Labels map[string]string
 
+//
+// Label model
 type Label struct {
-	Parent string `sql:"unique(a),key"`
-	Kind   string `sql:"unique(a),key"`
-	Name   string `sql:"unique(a)"`
+	PK     string `sql:"pk"`
+	Parent string `sql:"key"`
+	Kind   string `sql:"key"`
+	Name   string `sql:"key"`
 	Value  string `sql:""`
+}
+
+func (l *Label) Pk() string {
+	return l.PK
+}
+
+func (l *Label) String() string {
+	return ""
+}
+
+func (l *Label) Equals(other Model) bool {
+	if label, cast := other.(*Label); cast {
+		return label.Kind == l.Kind &&
+			label.Parent == l.Parent &&
+			label.Name == l.Name &&
+			label.Value == l.Value
+
+	}
+
+	return false
+}
+
+func (l *Label) Labels() Labels {
+	return nil
 }

--- a/pkg/inventory/model/model.go
+++ b/pkg/inventory/model/model.go
@@ -2,14 +2,12 @@ package model
 
 import (
 	"database/sql"
-	"errors"
 	_ "github.com/mattn/go-sqlite3"
 	"reflect"
 )
 
 //
 // Errors.
-var Conflict = errors.New("conflict")
 var NotFound = sql.ErrNoRows
 
 //
@@ -72,8 +70,6 @@ func (p *Page) Slice(collection interface{}) {
 type Model interface {
 	// Get the primary key.
 	Pk() string
-	// Set the primary key based on natural keys.
-	SetPk()
 	// Get description of the model.
 	String() string
 	// Equal comparison.

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -3,43 +3,41 @@ package model
 import (
 	"errors"
 	"fmt"
+	"github.com/konveyor/controller/pkg/ref"
 	"github.com/onsi/gomega"
 	"math"
 	"testing"
 	"time"
 )
 
-type Thing struct {
-	PK       string `sql:"pk"`
+type TestObject struct {
+	PK       string `sql:"pk,generated(id)"`
 	ID       int    `sql:"key"`
-	Name     string `sql:"key"`
-	Revision int64  `sql:"revision"`
-	Int8     int8   `sql:"int8"`
-	Int16    int16  `sql:"int16"`
-	Int32    int32  `sql:"int32"`
+	Name     string `sql:""`
+	Age      int    `sql:""`
+	Int8     int8   `sql:""`
+	Int16    int16  `sql:""`
+	Int32    int32  `sql:""`
+	Bool     bool   `sql:""`
 	labels   Labels
 }
 
-func (m *Thing) Pk() string {
-	return m.PK
+func (m *TestObject) Pk() string {
+	return fmt.Sprintf("%s", m.PK)
 }
 
-func (m *Thing) SetPk() {
-	m.PK = fmt.Sprintf("%d", m.ID)
-}
-
-func (m *Thing) String() string {
+func (m *TestObject) String() string {
 	return fmt.Sprintf(
-		"Thing: id: %d, name:%s",
+		"TestObject: id: %d, name:%s",
 		m.ID,
 		m.Name)
 }
 
-func (m *Thing) Equals(other Model) bool {
+func (m *TestObject) Equals(other Model) bool {
 	return false
 }
 
-func (m *Thing) Labels() Labels {
+func (m *TestObject) Labels() Labels {
 	return m.labels
 }
 
@@ -52,20 +50,20 @@ type TestHandler struct {
 	done    bool
 }
 
-func (w *TestHandler) Created(model Model) {
-	if thing, cast := model.(*Thing); cast {
-		w.created = append(w.created, thing.ID)
+func (w *TestHandler) Created(e Event) {
+	if object, cast := e.Model.(*TestObject); cast {
+		w.created = append(w.created, object.ID)
 	}
 }
 
-func (w *TestHandler) Updated(model Model) {
-	if thing, cast := model.(*Thing); cast {
-		w.updated = append(w.updated, thing.ID)
+func (w *TestHandler) Updated(e Event) {
+	if object, cast := e.Model.(*TestObject); cast {
+		w.updated = append(w.updated, object.ID)
 	}
 }
-func (w *TestHandler) Deleted(model Model) {
-	if thing, cast := model.(*Thing); cast {
-		w.deleted = append(w.deleted, thing.ID)
+func (w *TestHandler) Deleted(e Event) {
+	if object, cast := e.Model.(*TestObject); cast {
+		w.deleted = append(w.deleted, object.ID)
 	}
 }
 
@@ -76,138 +74,304 @@ func (w *TestHandler) Error(err error) {
 func (w *TestHandler) End() {
 }
 
-func TestModels(t *testing.T) {
+func TestCRUD(t *testing.T) {
 	var err error
-
 	g := gomega.NewGomegaWithT(t)
-
-	// Build the DB.
 	DB := New(
 		"/tmp/test.db",
 		&Label{},
-		&Thing{})
+		&TestObject{})
 	err = DB.Open(true)
 	g.Expect(err).To(gomega.BeNil())
-	g.Expect(DB.(*Client).db).ToNot(gomega.BeNil())
-
-	// Test create handler.
-	DB.Journal().Enable()
-	handlerA := &TestHandler{name: "A"}
-	watchA, err := DB.Watch(&Thing{}, handlerA)
-	g.Expect(watchA).ToNot(gomega.BeNil())
-	g.Expect(err).To(gomega.BeNil())
-
-	// Create a model.
-	thing := &Thing{
-		ID:   0,
-		Name: "Elmer",
+	objA := &TestObject{
+		ID:    0,
+		Name:  "Elmer",
+		Age:   18,
+		Int8:  8,
+		Int16: 16,
+		Int32: 32,
+		Bool:  true,
 		labels: Labels{
-			"role": "main",
+			"n1": "v1",
+			"n2": "v2",
 		},
 	}
+	assertEqual := func(a, b *TestObject) {
+		g.Expect(a.PK).To(gomega.Equal(b.PK))
+		g.Expect(a.ID).To(gomega.Equal(b.ID))
+		g.Expect(a.Name).To(gomega.Equal(b.Name))
+		g.Expect(a.Age).To(gomega.Equal(b.Age))
+		g.Expect(a.Int8).To(gomega.Equal(b.Int8))
+		g.Expect(a.Int16).To(gomega.Equal(b.Int16))
+		g.Expect(a.Int32).To(gomega.Equal(b.Int32))
+		g.Expect(a.Bool).To(gomega.Equal(b.Bool))
+		for k, v := range objA.labels {
+			l := &Label{
+				Kind:   ref.ToKind(a),
+				Parent: a.PK,
+				Name:   k,
+			}
+			g.Expect(DB.Get(l)).To(gomega.BeNil())
+			g.Expect(v).To(gomega.Equal(l.Value))
+		}
+	}
+	// Insert
+	err = DB.Insert(objA)
+	g.Expect(err).To(gomega.BeNil())
+	objB := &TestObject{ID: objA.ID}
+	// Get
+	err = DB.Get(objB)
+	g.Expect(err).To(gomega.BeNil())
+	assertEqual(objA, objB)
+	// Update
+	objA.Name = "Larry"
+	objA.Age = 21
+	objA.Bool = false
+	err = DB.Update(objA)
+	g.Expect(err).To(gomega.BeNil())
+	// Get
+	objB = &TestObject{ID: objA.ID}
+	err = DB.Get(objB)
+	g.Expect(err).To(gomega.BeNil())
+	assertEqual(objA, objB)
+	// Delete
+	objA = &TestObject{ID: objA.ID}
+	err = DB.Delete(objA)
+	g.Expect(err).To(gomega.BeNil())
+	// Get (not found)
+	objB = &TestObject{ID: objA.ID}
+	err = DB.Get(objB)
+	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
+}
 
-	// Test CRUD.
-	err = DB.Insert(thing)
+func TestTransactions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	DB := New(
+		"/tmp/test.db",
+		&Label{},
+		&TestObject{})
+	err := DB.Open(true)
 	g.Expect(err).To(gomega.BeNil())
-	err = DB.Get(thing)
-	g.Expect(err).To(gomega.BeNil())
-	err = DB.Update(thing)
-	g.Expect(err).To(gomega.BeNil())
-
-	// Test conflict.
-	DB.Update(thing)
-	err = DB.Update(thing)
-	g.Expect(err).To(gomega.BeNil())
-	err = DB.Update(thing)
-	g.Expect(errors.Is(err, Conflict)).To(gomega.BeTrue())
-
-	// Test List
-	list := []Thing{}
-	err = DB.List(thing, ListOptions{}, &list)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(len(list)).To(gomega.Equal(1))
-
-	// Test List by label.
-	list = []Thing{}
-	err = DB.List(
-		thing,
-		ListOptions{
-			Labels: Labels{
-				"role": "main",
-			}},
-		&list)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(len(list)).To(gomega.Equal(1))
-	list = []Thing{}
-	err = DB.List(
-		thing,
-		ListOptions{
-			Labels: Labels{
-				"job": "other",
-			}},
-		&list)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(len(list)).To(gomega.Equal(0))
-
-	// Test Tx - commit
-	thing.ID = 1
+	// Begin
 	tx, err := DB.Begin()
+	defer tx.End()
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(tx.ref).To(gomega.Equal(DB.(*Client).tx))
-	err = DB.Insert(thing)
+	object := &TestObject{
+		ID:   0,
+		Name: "Elmer",
+	}
+	err = DB.Insert(object)
 	g.Expect(err).To(gomega.BeNil())
-	err = DB.Get(thing)
+	// Get (not found)
+	object = &TestObject{ID: object.ID}
+	err = DB.Get(object)
 	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
-	err = tx.Commit()
+	tx.Commit()
+	// Get (found)
+	object = &TestObject{ID: object.ID}
+	err = DB.Get(object)
 	g.Expect(err).To(gomega.BeNil())
-	g.Expect(DB.(*Client).tx).To(gomega.BeNil())
-	err = DB.Get(thing)
-	g.Expect(err).To(gomega.BeNil())
+}
 
-	// Test Tx - rollback
-	thing.ID = 2
-	tx, err = DB.Begin()
+func TestGetForUpdate(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	DB := New(
+		"/tmp/test.db",
+		&Label{},
+		&TestObject{})
+	err := DB.Open(true)
 	g.Expect(err).To(gomega.BeNil())
-	err = DB.Insert(thing)
+	// Insert
+	object := &TestObject{
+		ID:   0,
+		Name: "Elmer",
+	}
+	err = DB.Insert(object)
 	g.Expect(err).To(gomega.BeNil())
-	err = DB.Get(thing)
-	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
-	tx.End()
-	g.Expect(DB.(*Client).tx).To(gomega.BeNil())
-	err = DB.Get(thing)
-	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
+	tx, err := DB.GetForUpdate(object)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(tx.ref).To(gomega.Equal(DB.(*Client).tx))
+	tx.Commit()
+}
 
-	handlerB := &TestHandler{name: "B"}
-	watchB, err := DB.Watch(&Thing{}, handlerB)
-	g.Expect(watchB).ToNot(gomega.BeNil())
+func TestList(t *testing.T) {
+	var err error
+	g := gomega.NewGomegaWithT(t)
+	DB := New(
+		"/tmp/test.db",
+		&Label{},
+		&TestObject{})
+	err = DB.Open(true)
 	g.Expect(err).To(gomega.BeNil())
-
-	created := []int{0, 1}
-	updated := []int{0, 0}
-	for i := 2; i < 100; i++ {
-		created = append(created, i)
-		thing.ID = i
-		err = DB.Insert(thing)
+	for i := 0; i < 10; i++ {
+		object := &TestObject{
+			ID: i,
+			labels: Labels{
+				"id": fmt.Sprintf("v%d", i),
+			},
+		}
+		err = DB.Insert(object)
 		g.Expect(err).To(gomega.BeNil())
 	}
+	// List all.
+	list := []TestObject{}
+	err = DB.List(&TestObject{}, ListOptions{}, &list)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(list)).To(gomega.Equal(10))
+	// List = (single).
+	list = []TestObject{}
+	err = DB.List(
+		&TestObject{},
+		ListOptions{
+			Predicate: Eq("ID", 0),
+		},
+		&list)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(list)).To(gomega.Equal(1))
+	g.Expect(list[0].ID).To(gomega.Equal(0))
+	// List != AND
+	list = []TestObject{}
+	err = DB.List(
+		&TestObject{},
+		ListOptions{
+			Predicate: And( // Even only.
+				Neq("ID", 1),
+				Neq("ID", 3),
+				Neq("ID", 5),
+				Neq("ID", 7),
+				Neq("ID", 9)),
+		},
+		&list)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(list)).To(gomega.Equal(5))
+	g.Expect(list[0].ID).To(gomega.Equal(0))
+	g.Expect(list[1].ID).To(gomega.Equal(2))
+	g.Expect(list[2].ID).To(gomega.Equal(4))
+	g.Expect(list[3].ID).To(gomega.Equal(6))
+	g.Expect(list[4].ID).To(gomega.Equal(8))
+	// List OR =.
+	list = []TestObject{}
+	err = DB.List(
+		&TestObject{},
+		ListOptions{
+			Predicate: Or(
+				Eq("ID", 0),
+				Eq("ID", 6)),
+		},
+		&list)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list[0].ID).To(gomega.Equal(0))
+	g.Expect(list[1].ID).To(gomega.Equal(6))
+	// List < (lt).
+	list = []TestObject{}
+	err = DB.List(
+		&TestObject{},
+		ListOptions{
+			Predicate: Lt("ID", 2),
+		},
+		&list)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list[0].ID).To(gomega.Equal(0))
+	g.Expect(list[1].ID).To(gomega.Equal(1))
+	// List > (gt).
+	list = []TestObject{}
+	err = DB.List(
+		&TestObject{},
+		ListOptions{
+			Predicate: Gt("ID", 7),
+		},
+		&list)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list[0].ID).To(gomega.Equal(8))
+	g.Expect(list[1].ID).To(gomega.Equal(9))
+	// By label.
+	list = []TestObject{}
+	err = DB.List(
+		&TestObject{},
+		ListOptions{
+			Sort: []int{2},
+			Predicate: Or(
+				Match(Labels{"id": "v4"}),
+				Eq("ID", 8)),
+		},
+		&list)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list[0].ID).To(gomega.Equal(4))
+	g.Expect(list[1].ID).To(gomega.Equal(8))
+}
 
-	for i := 0; i < 10; i++ {
+func TestWatch(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	DB := New(
+		"/tmp/test.db",
+		&Label{},
+		&TestObject{})
+	err := DB.Open(true)
+	g.Expect(err).To(gomega.BeNil())
+	DB.Journal().Enable()
+	// Handler A
+	handlerA := &TestHandler{name: "A"}
+	watchA, err := DB.Watch(&TestObject{}, handlerA)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(watchA).ToNot(gomega.BeNil())
+	N := 10
+	// Insert
+	for i := 0; i < N; i++ {
+		object := &TestObject{
+			ID:   i,
+			Name: "Elmer",
+		}
+		err = DB.Insert(object)
+		g.Expect(err).To(gomega.BeNil())
+	}
+	// Handler B
+	handlerB := &TestHandler{name: "B"}
+	watchB, err := DB.Watch(&TestObject{}, handlerA)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(watchB).ToNot(gomega.BeNil())
+	// Update
+	for i := 0; i < N; i++ {
+		object := &TestObject{
+			ID:   i,
+			Name: "Fudd",
+		}
+		err = DB.Update(object)
+		g.Expect(err).To(gomega.BeNil())
+	}
+	// Handler C
+	handlerC := &TestHandler{name: "C"}
+	watchC, err := DB.Watch(&TestObject{}, handlerC)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(watchC).ToNot(gomega.BeNil())
+	// Delete
+	for i := 0; i < N; i++ {
+		object := &TestObject{
+			ID: i,
+		}
+		err = DB.Delete(object)
+		g.Expect(err).To(gomega.BeNil())
+	}
+	for i := 0; i < N; i++ {
 		time.Sleep(time.Second)
-		if len(handlerA.created) != len(created) ||
-			len(handlerA.updated) != len(updated) ||
-			len(handlerB.created) != len(created) {
+		if len(handlerA.created) != N ||
+			len(handlerA.updated) != N ||
+			len(handlerA.created) != N ||
+			len(handlerB.created) != N ||
+			len(handlerB.updated) != N ||
+			len(handlerB.created) != N ||
+			len(handlerC.created) != N ||
+			len(handlerC.updated) != N ||
+			len(handlerC.created) != N {
 			continue
 		} else {
 			break
 		}
 	}
-
-	g.Expect(handlerA.created).To(
-		gomega.Equal(created))
-	g.Expect(handlerA.updated).To(
-		gomega.Equal(updated))
-	g.Expect(handlerB.created).To(
-		gomega.Equal(created))
 }
 
 //
@@ -215,14 +379,14 @@ func TestModels(t *testing.T) {
 func __TestConcurrency(t *testing.T) {
 	var err error
 
-	DB := New("/tmp/test.db", &Thing{})
+	DB := New("/tmp/test.db", &TestObject{})
 	DB.Open(true)
 
 	N := 1000
 
 	direct := func(done chan int) {
 		for i := 0; i < N; i++ {
-			m := &Thing{
+			m := &TestObject{
 				ID:   i,
 				Name: "direct",
 			}
@@ -238,7 +402,7 @@ func __TestConcurrency(t *testing.T) {
 	read := func(done chan int) {
 		time.Sleep(time.Second)
 		for i := 0; i < N; i++ {
-			m := &Thing{
+			m := &TestObject{
 				ID:   i,
 				Name: "direct",
 			}
@@ -260,7 +424,7 @@ func __TestConcurrency(t *testing.T) {
 	del := func(done chan int) {
 		time.Sleep(time.Second * 3)
 		for i := 0; i < N/2; i++ {
-			m := &Thing{
+			m := &TestObject{
 				ID: i,
 			}
 			go func() {
@@ -280,7 +444,7 @@ func __TestConcurrency(t *testing.T) {
 	}
 	update := func(done chan int) {
 		for i := 0; i < N; i++ {
-			m := &Thing{
+			m := &TestObject{
 				ID:   i,
 				Name: "direct",
 			}
@@ -309,7 +473,7 @@ func __TestConcurrency(t *testing.T) {
 					panic(err)
 				}
 			}
-			m := &Thing{
+			m := &TestObject{
 				ID:   i,
 				Name: "transaction",
 			}

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 type TestObject struct {
-	PK       string `sql:"pk,generated(id)"`
-	ID       int    `sql:"key"`
-	Name     string `sql:""`
-	Age      int    `sql:""`
-	Int8     int8   `sql:""`
-	Int16    int16  `sql:""`
-	Int32    int32  `sql:""`
-	Bool     bool   `sql:""`
-	labels   Labels
+	PK     string `sql:"pk,generated(id)"`
+	ID     int    `sql:"key"`
+	Name   string `sql:""`
+	Age    int    `sql:""`
+	Int8   int8   `sql:""`
+	Int16  int16  `sql:""`
+	Int32  int32  `sql:""`
+	Bool   bool   `sql:""`
+	labels Labels
 }
 
 func (m *TestObject) Pk() string {
@@ -216,24 +216,23 @@ func TestList(t *testing.T) {
 	}
 	// List all.
 	list := []TestObject{}
-	err = DB.List(&TestObject{}, ListOptions{}, &list)
+	err = DB.List(&list, ListOptions{})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(10))
 	// List = (single).
 	list = []TestObject{}
 	err = DB.List(
-		&TestObject{},
+		&list,
 		ListOptions{
 			Predicate: Eq("ID", 0),
-		},
-		&list)
+		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(1))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
 	// List != AND
 	list = []TestObject{}
 	err = DB.List(
-		&TestObject{},
+		&list,
 		ListOptions{
 			Predicate: And( // Even only.
 				Neq("ID", 1),
@@ -241,8 +240,7 @@ func TestList(t *testing.T) {
 				Neq("ID", 5),
 				Neq("ID", 7),
 				Neq("ID", 9)),
-		},
-		&list)
+		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(5))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
@@ -253,13 +251,12 @@ func TestList(t *testing.T) {
 	// List OR =.
 	list = []TestObject{}
 	err = DB.List(
-		&TestObject{},
+		&list,
 		ListOptions{
 			Predicate: Or(
 				Eq("ID", 0),
 				Eq("ID", 6)),
-		},
-		&list)
+		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(2))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
@@ -267,11 +264,10 @@ func TestList(t *testing.T) {
 	// List < (lt).
 	list = []TestObject{}
 	err = DB.List(
-		&TestObject{},
+		&list,
 		ListOptions{
 			Predicate: Lt("ID", 2),
-		},
-		&list)
+		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(2))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
@@ -279,11 +275,10 @@ func TestList(t *testing.T) {
 	// List > (gt).
 	list = []TestObject{}
 	err = DB.List(
-		&TestObject{},
+		&list,
 		ListOptions{
 			Predicate: Gt("ID", 7),
-		},
-		&list)
+		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(2))
 	g.Expect(list[0].ID).To(gomega.Equal(8))
@@ -291,14 +286,13 @@ func TestList(t *testing.T) {
 	// By label.
 	list = []TestObject{}
 	err = DB.List(
-		&TestObject{},
+		&list,
 		ListOptions{
 			Sort: []int{2},
 			Predicate: Or(
 				Match(Labels{"id": "v4"}),
 				Eq("ID", 8)),
-		},
-		&list)
+		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(2))
 	g.Expect(list[0].ID).To(gomega.Equal(4))
@@ -331,7 +325,7 @@ func TestWatch(t *testing.T) {
 	}
 	// Handler B
 	handlerB := &TestHandler{name: "B"}
-	watchB, err := DB.Watch(&TestObject{}, handlerA)
+	watchB, err := DB.Watch(&TestObject{}, handlerB)
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(watchB).ToNot(gomega.BeNil())
 	// Update
@@ -357,7 +351,7 @@ func TestWatch(t *testing.T) {
 		g.Expect(err).To(gomega.BeNil())
 	}
 	for i := 0; i < N; i++ {
-		time.Sleep(time.Second)
+		time.Sleep(time.Millisecond * 10)
 		if len(handlerA.created) != N ||
 			len(handlerA.updated) != N ||
 			len(handlerA.created) != N ||
@@ -365,7 +359,6 @@ func TestWatch(t *testing.T) {
 			len(handlerB.updated) != N ||
 			len(handlerB.created) != N ||
 			len(handlerC.created) != N ||
-			len(handlerC.updated) != N ||
 			len(handlerC.created) != N {
 			continue
 		} else {

--- a/pkg/inventory/model/predicate.go
+++ b/pkg/inventory/model/predicate.go
@@ -1,0 +1,418 @@
+package model
+
+import (
+	"bytes"
+	liberr "github.com/konveyor/controller/pkg/error"
+	"reflect"
+	"strings"
+	"text/template"
+)
+
+//
+// Label SQL.
+var LabelSQL = `
+{{ $kind := .Kind -}}
+{{ if .Len }}
+{{ .Pk.Name }} IN
+(
+{{ range $i,$l := .List -}}
+{{ if $i }}
+INTERSECT
+{{ end -}}
+SELECT parent
+FROM Label
+WHERE kind = '{{ $kind }}' AND
+name = {{ $l.Name }} AND
+value = {{ $l.Value }}
+{{ end -}}
+)
+{{ end -}}
+`
+
+//
+// New Eq (=) predicate.
+func Eq(field string, value interface{}) *EqPredicate {
+	return &EqPredicate{
+		SimplePredicate{
+			Field: field,
+			Value: value,
+		},
+	}
+}
+
+//
+// New Neq (!=) predicate.
+func Neq(field string, value interface{}) *NeqPredicate {
+	return &NeqPredicate{
+		SimplePredicate{
+			Field: field,
+			Value: value,
+		},
+	}
+}
+
+//
+// New Gt (>) predicate.
+func Gt(field string, value interface{}) *GtPredicate {
+	return &GtPredicate{
+		SimplePredicate{
+			Field: field,
+			Value: value,
+		},
+	}
+}
+
+//
+// New Lt (<) predicate.
+func Lt(field string, value interface{}) *LtPredicate {
+	return &LtPredicate{
+		SimplePredicate{
+			Field: field,
+			Value: value,
+		},
+	}
+}
+
+//
+// AND predicate.
+func And(predicates ...Predicate) *AndPredicate {
+	return &AndPredicate{
+		CompoundPredicate{
+			Predicates: predicates,
+		},
+	}
+}
+
+//
+// OR predicate.
+func Or(predicates ...Predicate) *OrPredicate {
+	return &OrPredicate{
+		CompoundPredicate{
+			Predicates: predicates,
+		},
+	}
+}
+
+//
+// Label predicate.
+func Match(labels Labels) *LabelPredicate {
+	return &LabelPredicate{
+		Labels: labels,
+	}
+}
+
+//
+// List predicate.
+type Predicate interface {
+	// Build the predicate.
+	Build(*ListOptions) error
+	// Get the SQL expression.
+	Expr() string
+}
+
+//
+// Simple predicate.
+type SimplePredicate struct {
+	// Field name.
+	Field string
+	// Field value.
+	Value interface{}
+	// SQL expression.
+	expr string
+}
+
+//
+// Find referenced field.
+func (p *SimplePredicate) match(fields []*Field) (*Field, bool) {
+	for _, f := range fields {
+		if f.Name == p.Field {
+			return f, true
+		}
+	}
+
+	return nil, false
+}
+
+//
+// Equals (=) predicate.
+type EqPredicate struct {
+	SimplePredicate
+}
+
+//
+// Build.
+func (p *EqPredicate) Build(options *ListOptions) error {
+	f, found := p.match(options.fields)
+	if !found {
+		return PredicateRefErr
+	}
+	v, err := f.AsValue(p.Value)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	p.expr = f.Name + " = " + options.Param(f.Name, v)
+	return nil
+}
+
+//
+// Render the expression.
+func (p *EqPredicate) Expr() string {
+	return p.expr
+}
+
+//
+// NotEqual (!=) predicate.
+type NeqPredicate struct {
+	SimplePredicate
+}
+
+//
+// Build.
+func (p *NeqPredicate) Build(options *ListOptions) error {
+	f, found := p.match(options.fields)
+	if !found {
+		return PredicateRefErr
+	}
+	v, err := f.AsValue(p.Value)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	p.expr = f.Name + " != " + options.Param(f.Name, v)
+	return nil
+}
+
+//
+// Render the expression.
+func (p *NeqPredicate) Expr() string {
+	return p.expr
+}
+
+//
+// Greater than (>) predicate.
+type GtPredicate struct {
+	SimplePredicate
+}
+
+//
+// Build.
+func (p *GtPredicate) Build(options *ListOptions) error {
+	f, found := p.match(options.fields)
+	if !found {
+		return PredicateRefErr
+	}
+	switch f.Value.Kind() {
+	case reflect.String,
+		reflect.Bool:
+		return PredicateTypeErr
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		v, err := f.AsValue(p.Value)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		p.expr = f.Name + " > " + options.Param(f.Name, v)
+		return nil
+	default:
+		return FieldTypeErr
+	}
+}
+
+//
+// Render the expression.
+func (p *GtPredicate) Expr() string {
+	return p.expr
+}
+
+//
+// Less than (<) predicate.
+type LtPredicate struct {
+	SimplePredicate
+}
+
+//
+// Build.
+func (p *LtPredicate) Build(options *ListOptions) error {
+	f, found := p.match(options.fields)
+	if !found {
+		return PredicateRefErr
+	}
+	switch f.Value.Kind() {
+	case reflect.String,
+		reflect.Bool:
+		return PredicateTypeErr
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		v, err := f.AsValue(p.Value)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		p.expr = f.Name + " < " + options.Param(f.Name, v)
+		return nil
+	default:
+		return FieldTypeErr
+	}
+}
+
+//
+// Render the expression.
+func (p *LtPredicate) Expr() string {
+	return p.expr
+}
+
+//
+// Compound predicate.
+type CompoundPredicate struct {
+	// List of predicates.
+	Predicates []Predicate
+}
+
+//
+// And predicate.
+type AndPredicate struct {
+	CompoundPredicate
+}
+
+//
+// Build.
+func (p *AndPredicate) Build(options *ListOptions) error {
+	for _, p := range p.Predicates {
+		err := p.Build(options)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+//
+// Render the expression.
+func (p *AndPredicate) Expr() string {
+	predicates := []string{}
+	for _, p := range p.Predicates {
+		predicates = append(predicates, p.Expr())
+	}
+
+	expr := strings.Join(predicates, " AND ")
+
+	return expr
+}
+
+//
+// OR predicate.
+type OrPredicate struct {
+	CompoundPredicate
+}
+
+//
+// Build.
+func (p *OrPredicate) Build(options *ListOptions) error {
+	for _, p := range p.Predicates {
+		err := p.Build(options)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+//
+// Render the expression.
+func (p *OrPredicate) Expr() string {
+	predicates := []string{}
+	for _, p := range p.Predicates {
+		predicates = append(predicates, p.Expr())
+	}
+
+	expr := strings.Join(predicates, " OR ")
+
+	return expr
+}
+
+//
+// Label predicate.
+type LabelPredicate struct {
+	// Labels
+	Labels
+	// List options.
+	options *ListOptions
+	// Parent PK field name.
+	pk *Field
+	// SQL expression.
+	expr string
+}
+
+//
+// Build.
+func (p *LabelPredicate) Build(options *ListOptions) error {
+	p.options = options
+	for _, f := range options.fields {
+		if f.Pk() {
+			p.pk = f
+			break
+		}
+	}
+	tpl := template.New("")
+	tpl, err := tpl.Parse(LabelSQL)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	bfr := &bytes.Buffer{}
+	err = tpl.Execute(bfr, p)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
+	p.expr = bfr.String()
+
+	return nil
+}
+
+//
+// Label (parent) kind.
+func (p *LabelPredicate) Kind() string {
+	return p.options.table
+}
+
+//
+// PK field name.
+func (p *LabelPredicate) Pk() *Field {
+	return p.pk
+}
+
+//
+// List of labels.
+func (p *LabelPredicate) List() []Label {
+	list := []Label{}
+	for k, v := range p.Labels {
+		k = p.options.Param("k", k)
+		v = p.options.Param("v", v)
+		list = append(
+			list,
+			Label{
+				Name:  k,
+				Value: v,
+			})
+	}
+
+	return list
+}
+
+//
+// Get the number of labels.
+func (p *LabelPredicate) Len() int {
+	return len(p.Labels)
+}
+
+//
+// Render the expression.
+func (p *LabelPredicate) Expr() string {
+	return p.expr
+}

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -2,13 +2,16 @@ package model
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"database/sql"
-	"errors"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/mattn/go-sqlite3"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 )
@@ -64,39 +67,17 @@ UPDATE {{.Table}}
 SET
 {{ range $i,$f := .Fields -}}
 {{ if $i }},{{ end -}}
-{{ $f.Name }} = 
-{{- if $f.Revision -}}
-{{ $f.Name }}+1
-{{ else -}}
-{{ $f.Param }}
-{{ end -}}
-{{ end -}}
-WHERE
-{{ if .Pk -}}
-{{ .Pk.Name }} = {{ .Pk.Param }}
-{{ if .Revision -}}
-AND {{ .Revision.Name }} = {{ .Revision.Param }}
-{{ end -}}
-{{ else -}}
-{{ range $i,$f := .Keys -}}
-{{ if $i }}AND {{ end -}}
 {{ $f.Name }} = {{ $f.Param }}
 {{ end -}}
-{{ end -}}
+WHERE
+{{ .Pk.Name }} = {{ .Pk.Param }}
 ;
 `
 
 var DeleteSQL = `
 DELETE FROM {{.Table}}
 WHERE
-{{ if .Pk -}}
 {{ .Pk.Name }} = {{ .Pk.Param }}
-{{ else -}}
-{{ range $i,$f := .Keys -}}
-{{ if $i }}AND {{ end -}}
-{{ $f.Name }} = {{ $f.Param }}
-{{ end -}}
-{{ end -}}
 ;
 `
 
@@ -108,14 +89,7 @@ SELECT
 {{ end -}}
 FROM {{.Table}}
 WHERE
-{{ if .Pk -}}
 {{ .Pk.Name }} = {{ .Pk.Param }}
-{{ else -}}
-{{ range $i,$f := .Keys -}}
-{{ if $i }}AND {{ end -}}
-{{ $f.Name }} = {{ $f.Param }}
-{{ end -}}
-{{ end -}}
 ;
 `
 
@@ -130,42 +104,46 @@ COUNT(*)
 {{ end -}}
 {{ end -}}
 FROM {{.Table}}
-{{ if or .NotEmpty .Labels -}}
+{{ if or .Predicate -}}
 WHERE
 {{ end -}}
-{{ $fCount := len .NotEmpty -}}
-{{ range $i,$f := .NotEmpty -}}
-{{ if $i }}AND {{ end -}}
-{{ $f.Name }} = {{ $f.Param }}
+{{ if .Predicate -}}
+{{ .Predicate.Expr }}
 {{ end -}}
-{{ if .Labels -}}
-{{ if $fCount }}AND {{ end -}}
-{{ .Pk.Name }} IN
-(
-{{ $kind := .Table -}}
-{{ range $i,$l := .Labels -}}
-{{ if $i }}
-INTERSECT
-{{ end -}}
-SELECT parent
-FROM Label
-WHERE kind = '{{ $kind }}' AND
-name = '{{$l.Name}}' AND
-value = '{{$l.Value}}'
-{{ end -}}
-)
-{{ end -}}
-{{ if .Options.Sort -}}
+{{ if .Sort -}}
 ORDER BY
-{{ range $i,$n := .Options.Sort -}}
+{{ range $i,$n := .Sort -}}
 {{ if $i }},{{ end }}{{ $n }}
 {{ end -}}
 {{ end -}}
-{{ if .Options.Page -}}
-LIMIT {{.Options.Page.Limit}} OFFSET {{.Options.Page.Offset}}
+{{ if .Page -}}
+LIMIT {{.Page.Limit}} OFFSET {{.Page.Offset}}
 {{ end -}}
 ;
 `
+
+//
+// Errors
+var (
+	// Must have PK.
+	MustHavePkErr = liberr.New("must have PK field.")
+	// Parameter must be pointer error.
+	MustBePtrErr = liberr.New("must be pointer")
+	// Parameter must be struct error.
+	MustBeObjectErr = liberr.New("must be object")
+	// Field type error.
+	FieldTypeErr = liberr.New("field type must be (integer, string, bool")
+	// PK field type error.
+	PkTypeErr = liberr.New("pk field must be (integer, string)")
+	// Generated PK error.
+	GenPkTypeErr = liberr.New("PK field must be `string` when generated")
+	// Invalid field referenced in predicate.
+	PredicateRefErr = liberr.New("predicate referenced unknown field")
+	// Invalid predicate for type of field.
+	PredicateTypeErr = liberr.New("predicate type not valid for field")
+	// Invalid predicate value.
+	PredicateValueErr = liberr.New("predicate value not valid")
+)
 
 //
 // Represents a table in the DB.
@@ -194,6 +172,23 @@ func (t Table) Name(model interface{}) string {
 }
 
 //
+// Validate the model.
+func (t Table) Validate(fields []*Field) error {
+	for _, f := range fields {
+		err := f.Validate()
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+	}
+	pk := t.PkField(fields)
+	if pk == nil {
+		return MustHavePkErr
+	}
+
+	return nil
+}
+
+//
 // Get table and index create DDL.
 func (t Table) DDL(model interface{}) ([]string, error) {
 	list := []string{}
@@ -202,11 +197,9 @@ func (t Table) DDL(model interface{}) ([]string, error) {
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
-	for _, f := range fields {
-		err := f.Validate()
-		if err != nil {
-			return nil, liberr.Wrap(err)
-		}
+	err = t.Validate(fields)
+	if err != nil {
+		return nil, liberr.Wrap(err)
 	}
 	// Table
 	tpl, err = tpl.Parse(TableDDL)
@@ -257,6 +250,7 @@ func (t Table) Insert(model interface{}) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	t.SetPk(fields)
 	stmt, err := t.insertSQL(t.Name(model), fields)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -287,6 +281,7 @@ func (t Table) Update(model interface{}) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	t.SetPk(fields)
 	stmt, err := t.updateSQL(t.Name(model), fields)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -301,11 +296,7 @@ func (t Table) Update(model interface{}) error {
 		return liberr.Wrap(err)
 	}
 	if nRows == 0 {
-		if t.Get(model) == nil {
-			return liberr.Wrap(Conflict)
-		} else {
-			return liberr.Wrap(NotFound)
-		}
+		return liberr.Wrap(NotFound)
 	}
 
 	return nil
@@ -319,6 +310,7 @@ func (t Table) Delete(model interface{}) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	t.SetPk(fields)
 	stmt, err := t.deleteSQL(t.Name(model), fields)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -348,6 +340,7 @@ func (t Table) Get(model interface{}) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	t.SetPk(fields)
 	stmt, err := t.getSQL(t.Name(model), fields)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -369,11 +362,11 @@ func (t Table) List(model interface{}, options ListOptions) ([]interface{}, erro
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
-	stmt, err := t.listSQL(t.Name(model), fields, options)
+	stmt, err := t.listSQL(t.Name(model), fields, &options)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
-	params := t.Params(fields)
+	params := append(t.Params(fields), options.Params()...)
 	cursor, err := t.DB.Query(stmt, params...)
 	if err != nil {
 		return nil, liberr.Wrap(err)
@@ -406,7 +399,7 @@ func (t Table) Count(model interface{}, options ListOptions) (int64, error) {
 		return 0, liberr.Wrap(err)
 	}
 	options.Count = true
-	stmt, err := t.listSQL(t.Name(model), fields, options)
+	stmt, err := t.listSQL(t.Name(model), fields, &options)
 	if err != nil {
 		return 0, liberr.Wrap(err)
 	}
@@ -434,38 +427,39 @@ func (t Table) Fields(model interface{}) ([]*Field, error) {
 		mt = mt.Elem()
 		mv = mv.Elem()
 	} else {
-		return nil, errors.New("must be pointer")
+		return nil, MustBePtrErr
 	}
 	if mv.Kind() != reflect.Struct {
-		return nil, errors.New("must be object")
+		return nil, MustBeObjectErr
 	}
 	for i := 0; i < mt.NumField(); i++ {
 		ft := mt.Field(i)
 		fv := mv.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
 		switch fv.Kind() {
 		case reflect.Struct:
-			sfields, err := t.Fields(fv.Addr().Interface())
+			nested, err := t.Fields(fv.Addr().Interface())
 			if err != nil {
 				return nil, nil
 			}
-			fields = append(fields, sfields...)
-		case reflect.String:
-			fields = append(
-				fields,
-				&Field{
-					Tag:   ft.Tag.Get(Tag),
-					Name:  ft.Name,
-					Value: &fv,
-				})
-		case reflect.Int,
+			fields = append(fields, nested...)
+		case reflect.String,
+			reflect.Bool,
+			reflect.Int,
 			reflect.Int8,
 			reflect.Int16,
 			reflect.Int32,
 			reflect.Int64:
+			sqlTag, found := ft.Tag.Lookup(Tag)
+			if !found {
+				continue
+			}
 			fields = append(
 				fields,
 				&Field{
-					Tag:   ft.Tag.Get(Tag),
+					Tag:   sqlTag,
 					Name:  ft.Name,
 					Value: &fv,
 				})
@@ -473,19 +467,6 @@ func (t Table) Fields(model interface{}) ([]*Field, error) {
 	}
 
 	return fields, nil
-}
-
-//
-// Get the populated `Fields` for the model.
-func (t Table) NotEmptyFields(fields []*Field) []*Field {
-	list := []*Field{}
-	for _, f := range fields {
-		if !f.Empty() {
-			list = append(list, f)
-		}
-	}
-
-	return list
 }
 
 //
@@ -500,6 +481,45 @@ func (t Table) Params(fields []*Field) []interface{} {
 	}
 
 	return list
+}
+
+//
+// Set PK
+// Generated when not already set as sha1
+// of the (const) natural keys.
+func (t Table) SetPk(fields []*Field) error {
+	pk := t.PkField(fields)
+	if pk == nil {
+		return nil
+	}
+	switch pk.Value.Kind() {
+	case reflect.String:
+		if pk.Pull() != "" {
+			return nil
+		}
+	default:
+		return GenPkTypeErr
+	}
+	h := sha1.New()
+	for _, f := range t.KeyFields(fields) {
+		f.Pull()
+		switch f.Value.Kind() {
+		case reflect.String:
+			h.Write([]byte(f.string))
+		case reflect.Bool,
+			reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			bfr := new(bytes.Buffer)
+			binary.Write(bfr, binary.BigEndian, f.int)
+			h.Write(bfr.Bytes())
+		}
+	}
+	pk.string = hex.EncodeToString(h.Sum(nil))
+	pk.Push()
+	return nil
 }
 
 //
@@ -533,18 +553,6 @@ func (t Table) KeyFields(fields []*Field) []*Field {
 func (t Table) PkField(fields []*Field) *Field {
 	for _, f := range fields {
 		if f.Pk() {
-			return f
-		}
-	}
-
-	return nil
-}
-
-//
-// Get the Revision field.
-func (t Table) RevisionField(fields []*Field) *Field {
-	for _, f := range fields {
-		if f.Revision() {
 			return f
 		}
 	}
@@ -619,11 +627,9 @@ func (t Table) updateSQL(table string, fields []*Field) (string, error) {
 	err = tpl.Execute(
 		bfr,
 		TmplData{
-			Table:    table,
-			Fields:   t.MutableFields(fields),
-			Revision: t.RevisionField(fields),
-			Keys:     t.KeyFields(fields),
-			Pk:       t.PkField(fields),
+			Table:  table,
+			Fields: t.MutableFields(fields),
+			Pk:     t.PkField(fields),
 		})
 	if err != nil {
 		return "", liberr.Wrap(err)
@@ -645,7 +651,6 @@ func (t Table) deleteSQL(table string, fields []*Field) (string, error) {
 		bfr,
 		TmplData{
 			Table: table,
-			Keys:  t.KeyFields(fields),
 			Pk:    t.PkField(fields),
 		})
 	if err != nil {
@@ -668,7 +673,7 @@ func (t Table) getSQL(table string, fields []*Field) (string, error) {
 		bfr,
 		TmplData{
 			Table:  table,
-			Keys:   t.KeyFields(fields),
+			Pk:     t.PkField(fields),
 			Fields: fields,
 		})
 	if err != nil {
@@ -680,9 +685,13 @@ func (t Table) getSQL(table string, fields []*Field) (string, error) {
 
 //
 // Build model list SQL.
-func (t Table) listSQL(table string, fields []*Field, options ListOptions) (string, error) {
+func (t Table) listSQL(table string, fields []*Field, options *ListOptions) (string, error) {
 	tpl := template.New("")
 	tpl, err := tpl.Parse(ListSQL)
+	if err != nil {
+		return "", liberr.Wrap(err)
+	}
+	err = options.Build(table, fields)
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
@@ -690,12 +699,10 @@ func (t Table) listSQL(table string, fields []*Field, options ListOptions) (stri
 	err = tpl.Execute(
 		bfr,
 		TmplData{
-			Table:    table,
-			Fields:   fields,
-			NotEmpty: t.NotEmptyFields(fields),
-			Options:  options,
-			Pk:       t.PkField(fields),
-			Count:    options.Count,
+			Table:   table,
+			Fields:  fields,
+			Options: options,
+			Pk:      t.PkField(fields),
 		})
 	if err != nil {
 		return "", liberr.Wrap(err)
@@ -744,8 +751,6 @@ var FkRegex = regexp.MustCompile(`(fk):(.+)(\()(.+)(\))`)
 //       Unique index. `G` = unique-together fields.
 //   `sql:"const"`
 //       The field is immutable and not included on update.
-//   `sql:"revision"`
-//       The field is used in detect an update conflict.
 //
 type Field struct {
 	// reflect.Value of the field.
@@ -766,19 +771,18 @@ type Field struct {
 // Validate.
 func (f *Field) Validate() error {
 	switch f.Value.Kind() {
-	case reflect.String:
-		if f.Revision() {
-			err := errors.New("revision must be integer")
-			return liberr.Wrap(err)
+	case reflect.Bool:
+		if f.Pk() {
+			return PkTypeErr
 		}
-	case reflect.Int,
+	case reflect.String,
+		reflect.Int,
 		reflect.Int8,
 		reflect.Int16,
 		reflect.Int32,
 		reflect.Int64:
 	default:
-		err := errors.New("must be: (string, int)")
-		return liberr.Wrap(err)
+		return FieldTypeErr
 	}
 
 	return nil
@@ -793,6 +797,12 @@ func (f *Field) Pull() interface{} {
 	case reflect.String:
 		f.string = f.Value.String()
 		return f.string
+	case reflect.Bool:
+		b := f.Value.Bool()
+		if b {
+			f.int = 1
+		}
+		return f.int
 	case reflect.Int,
 		reflect.Int8,
 		reflect.Int16,
@@ -811,7 +821,8 @@ func (f *Field) Ptr() interface{} {
 	switch f.Value.Kind() {
 	case reflect.String:
 		return &f.string
-	case reflect.Int,
+	case reflect.Bool,
+		reflect.Int,
 		reflect.Int8,
 		reflect.Int16,
 		reflect.Int32,
@@ -829,6 +840,12 @@ func (f *Field) Push() {
 	switch f.Value.Kind() {
 	case reflect.String:
 		f.Value.SetString(f.string)
+	case reflect.Bool:
+		b := false
+		if f.int != 0 {
+			b = true
+		}
+		f.Value.SetBool(b)
 	case reflect.Int,
 		reflect.Int8,
 		reflect.Int16,
@@ -849,7 +866,8 @@ func (f *Field) DDL() string {
 	switch f.Value.Kind() {
 	case reflect.String:
 		part[1] = "TEXT"
-	case reflect.Int,
+	case reflect.Bool,
+		reflect.Int,
 		reflect.Int8,
 		reflect.Int16,
 		reflect.Int32,
@@ -873,24 +891,6 @@ func (f *Field) Param() string {
 }
 
 //
-// Get whether field is empty.
-func (f *Field) Empty() bool {
-	f.Pull()
-	switch f.Value.Kind() {
-	case reflect.String:
-		return len(f.string) == 0
-	case reflect.Int,
-		reflect.Int8,
-		reflect.Int16,
-		reflect.Int32,
-		reflect.Int64:
-		return f.int == 0
-	}
-
-	return false
-}
-
-//
 // Get whether field is the primary key.
 func (f *Field) Pk() bool {
 	return f.hasOpt("pk")
@@ -900,7 +900,7 @@ func (f *Field) Pk() bool {
 // Get whether field is mutable.
 // Only mutable fields will be updated.
 func (f *Field) Mutable() bool {
-	if f.Pk() {
+	if f.Pk() || f.Key() {
 		return false
 	}
 
@@ -945,10 +945,93 @@ func (f *Field) Fk() *FK {
 	return nil
 }
 
-//
-// Get whether field is used for revision management.
-func (f *Field) Revision() bool {
-	return f.hasOpt("revision")
+// Convert the specified `object` to a value
+// (type) appropriate for the field.
+func (f *Field) AsValue(object interface{}) (value interface{}, err error) {
+	val := reflect.ValueOf(object)
+	switch val.Kind() {
+	case reflect.Ptr:
+		val = val.Elem()
+	case reflect.Struct:
+		err = PredicateValueErr
+		return
+	}
+	switch f.Value.Kind() {
+	case reflect.String:
+		switch val.Kind() {
+		case reflect.String:
+			value = val.String()
+		case reflect.Bool:
+			b := val.Bool()
+			value = strconv.FormatBool(b)
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			n := val.Int()
+			value = strconv.FormatInt(n, 0)
+		default:
+			err = PredicateValueErr
+		}
+	case reflect.Bool:
+		switch val.Kind() {
+		case reflect.String:
+			s := val.String()
+			b, pErr := strconv.ParseBool(s)
+			if err != nil {
+				err = liberr.Wrap(pErr)
+				return
+			}
+			value = b
+		case reflect.Bool:
+			value = val.Bool()
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			n := val.Int()
+			if n != 0 {
+				value = true
+			} else {
+				value = false
+			}
+		default:
+			err = PredicateValueErr
+		}
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		switch val.Kind() {
+		case reflect.String:
+			n, err := strconv.ParseInt(val.String(), 0, 64)
+			if err != nil {
+				err = liberr.Wrap(err)
+			}
+			value = n
+		case reflect.Bool:
+			if val.Bool() {
+				value = 1
+			} else {
+				value = 0
+			}
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			value = val.Int()
+		default:
+			err = PredicateValueErr
+		}
+	default:
+		err = FieldTypeErr
+	}
+
+	return
 }
 
 //
@@ -994,30 +1077,34 @@ type TmplData struct {
 	Constraints []string
 	// Natural key fields.
 	Keys []*Field
-	// Set (not empty) fields.
-	NotEmpty []*Field
 	// Primary key.
 	Pk *Field
-	// Revision to update.
-	Revision *Field
 	// List options.
-	Options ListOptions
-	// Row count.
-	Count bool
+	Options *ListOptions
 }
 
 //
-// Labels list.
-func (t TmplData) Labels() []Label {
-	list := []Label{}
-	for k, v := range t.Options.Labels {
-		list = append(list, Label{
-			Name:  k,
-			Value: v,
-		})
-	}
+// Predicate
+func (t TmplData) Predicate() Predicate {
+	return t.Options.Predicate
+}
 
-	return list
+//
+// Pagination.
+func (t TmplData) Page() *Page {
+	return t.Options.Page
+}
+
+//
+// Sort criteria
+func (t TmplData) Sort() []int {
+	return t.Options.Sort
+}
+
+//
+// Count only.
+func (t TmplData) Count() bool {
+	return t.Options.Count
 }
 
 //
@@ -1025,10 +1112,47 @@ func (t TmplData) Labels() []Label {
 type ListOptions struct {
 	// Row count.
 	Count bool
-	// Labels.
-	Labels Labels
 	// Pagination.
 	Page *Page
 	// Sort by field position.
 	Sort []int
+	// Predicate
+	Predicate Predicate
+	// Table (name).
+	table string
+	// Fields.
+	fields []*Field
+	// Params.
+	params []interface{}
+}
+
+//
+// Validate options.
+func (l *ListOptions) Build(table string, fields []*Field) error {
+	l.table = table
+	l.fields = fields
+	if l.Predicate == nil {
+		return nil
+	}
+	err := l.Predicate.Build(l)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
+	return nil
+}
+
+//
+// Get an appropriate parameter name.
+// Builds a parameter and adds it to the options.param list.
+func (l *ListOptions) Param(name string, value interface{}) string {
+	name = fmt.Sprintf("%s%d", name, len(l.params))
+	l.params = append(l.params, sql.Named(name, value))
+	return ":" + name
+}
+
+//
+// Get params referenced by the predicate.
+func (l *ListOptions) Params() []interface{} {
+	return l.params
 }


### PR DESCRIPTION
Model enhancements:
- Model watch event handler passed `Event` instead of `Model`.
- For _update_ events, the `Event.Updated` is populated.  This is needed so the handler can determine what changed (like controller-runtime predicates).
- The `Table` can generate the model _PK_ (primary key) field when not already set.  It is set as the sha256 of the _natural_ key fields.  This is currently implemented by each model but can be done by the `Table` since it has all the same information.  The `SetPk()` can be removed from the `Model` _interface_.

Unrelated:
- Renamed `Client.mutex` to `Client.dbMutex` for clarity.
- The `Journal.Client` field was removed.  The journal should never use the `Client` in which it is contained because it (the client)  is calling methods on the journal and has already acquired it's _mutex_.  Calling back to the client will result in deadloack.
- Added support for _bool_ types in the model.
- Added _List Predicates_.  Before, models were listed by setting any populated field in the _Where_ clause.  This does not work well for _int_ and _bool_ fields as they are always set.  Predicates support choosing which fields to select on as well as the comparison operator (=,!=,>,<).  The `And` and `Or` compound predicates support compound expressions.  Predicates are not intended to support the entire SQL _Where_ clause but provide structured support for basic expressions.  Re-implemented list by label match as predicate. 
- Added predefined errors.
- Updated Table.List() to determine the model _Type_ based on the _slice_ argument.  As a result, the List() no longer needs both a model instance and list passed.  Instead, just List(*[]Model, ListOptions).  Much simpler.

These ^ general model enhancements are the next, planned iteration.
