### PR TITLE
Add itinerary

### DIFF
--- a/pkg/itinerary/doc.go
+++ b/pkg/itinerary/doc.go
@@ -1,0 +1,1 @@
+package itinerary

--- a/pkg/itinerary/simple.go
+++ b/pkg/itinerary/simple.go
@@ -1,0 +1,145 @@
+package itinerary
+
+import liberr "github.com/konveyor/controller/pkg/error"
+
+//
+// List of steps.
+type Pipeline []Step
+
+//
+// Predicate flag.
+type Flag = int16
+
+//
+// Predicate.
+// Flags delegated to the predicate.
+type Predicate interface {
+	Allowed(Flag) (bool, error)
+}
+
+//
+// Itinerary step.
+type Step struct {
+	// Name.
+	Name string
+	// Any of these conditions be satisfied for
+	// the step to be included.
+	All Flag
+	// All of these conditions be satisfied for
+	// the step to be included.
+	Any Flag
+}
+
+//
+// An itinerary.
+// List of conditional steps.
+type Itinerary struct {
+	// Pipeline (list) of steps.
+	Pipeline
+	// Predicate.
+	Predicate
+	// Name.
+	Name string
+}
+
+//
+// Errors.
+var (
+	StepNotFound = liberr.New("step not found")
+)
+
+//
+// Get the current step.
+func (r *Itinerary) Get(name string) (*Step, error) {
+	for i := 0; i < len(r.Pipeline); i++ {
+		step := &r.Pipeline[i]
+		if step.Name == name {
+			return step, nil
+		}
+	}
+
+	return nil, StepNotFound
+}
+
+//
+// Get the next step in the itinerary.
+func (r *Itinerary) Next(name string) (next *Step, done bool, err error) {
+	current := -1
+	for i := 0; i < len(r.Pipeline); i++ {
+		step := &r.Pipeline[i]
+		if step.Name == name {
+			current = i
+		}
+	}
+	if current == -1 {
+		err = StepNotFound
+		return
+	}
+	for i := current + 1; i < len(r.Pipeline); i++ {
+		step := &r.Pipeline[i]
+		allowed, pErr := r.hasAny(step)
+		if pErr != nil {
+			err = pErr
+			return
+		}
+		if !allowed {
+			continue
+		}
+		allowed, pErr = r.hasAll(step)
+		if pErr != nil {
+			err = pErr
+			return
+		}
+		if !allowed {
+			continue
+		}
+
+		next = step
+		return
+	}
+
+	done = true
+	return
+}
+
+//
+// The step has satisfied ANY of the predicates.
+func (r *Itinerary) hasAny(step *Step) (allowed bool, err error) {
+	for i := 0; i < 16; i++ {
+		flag := Flag(1 << i)
+		if (step.Any & flag) == 0 {
+			continue
+		}
+		if r.Predicate == nil {
+			continue
+		}
+		allowed, err = r.Predicate.Allowed(flag)
+		if allowed || err != nil {
+			return
+		}
+	}
+
+	allowed = true
+	return
+}
+
+//
+// The step has satisfied ALL of the predicates.
+func (r *Itinerary) hasAll(step *Step) (allowed bool, err error) {
+	for i := 0; i < 16; i++ {
+		flag := Flag(1 << i)
+		if (step.All & flag) == 0 {
+			continue
+		}
+		if r.Predicate == nil {
+			continue
+		}
+		allowed, err = r.Predicate.Allowed(flag)
+		if !allowed || err != nil {
+			return
+		}
+	}
+
+	allowed = true
+	return
+}

--- a/pkg/itinerary/simple_test.go
+++ b/pkg/itinerary/simple_test.go
@@ -1,0 +1,112 @@
+package itinerary
+
+import (
+	"errors"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+var (
+	p1 Flag = 0x01
+	p2 Flag = 0x02
+	p3 Flag = 0x04
+)
+
+type TestPredicate struct {
+}
+
+func (p *TestPredicate) Allowed(f Flag) (bool, error) {
+	switch f {
+	case p1:
+		return false, nil
+	case p2:
+		return true, nil
+	case p3:
+		return true, nil
+	}
+
+	return true, nil
+}
+
+func TestGet(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	itinerary := Itinerary{
+		Name: "Test",
+		Pipeline: Pipeline{
+			Step{Name: "ONE"},
+			Step{Name: "TWO"},
+			Step{Name: "THREE"},
+		},
+	}
+
+	current, err := itinerary.Get("TWO")
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(current.Name).To(gomega.Equal("TWO"))
+}
+
+func TestNext(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	itinerary := Itinerary{
+		Name: "Test",
+		Pipeline: Pipeline{
+			Step{Name: "ONE"},
+			Step{Name: "TWO"},
+			Step{Name: "THREE"},
+		},
+	}
+
+	// ONE
+	next, done, err := itinerary.Next("ONE")
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(done).To(gomega.BeFalse())
+	g.Expect(next.Name).To(gomega.Equal("TWO"))
+	// TWO
+	next, done, err = itinerary.Next(next.Name)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(done).To(gomega.BeFalse())
+	g.Expect(next.Name).To(gomega.Equal("THREE"))
+	// THREE
+	next, done, err = itinerary.Next(next.Name)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(done).To(gomega.BeTrue())
+	g.Expect(next).To(gomega.BeNil())
+}
+
+func TestNextWithPredicate(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	itinerary := Itinerary{
+		Name: "Test",
+		Pipeline: Pipeline{
+			Step{Name: "ONE"},
+			Step{Name: "ONE-1", All: p1},
+			Step{Name: "TWO", All: p2 | p3},
+			Step{Name: "THREE", Any: p1 | p2},
+		},
+	}
+
+	itinerary.Predicate = &TestPredicate{}
+
+	// ONE
+	next, done, err := itinerary.Next("ONE")
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(done).To(gomega.BeFalse())
+	g.Expect(next.Name).To(gomega.Equal("TWO"))
+	// TWO
+	next, done, err = itinerary.Next(next.Name)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(done).To(gomega.BeFalse())
+	g.Expect(next.Name).To(gomega.Equal("THREE"))
+	// THREE
+	next, done, err = itinerary.Next(next.Name)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(done).To(gomega.BeTrue())
+	g.Expect(next).To(gomega.BeNil())
+
+	// Step Not Found
+	next, done, err = itinerary.Next("unknown")
+	g.Expect(errors.Is(err, StepNotFound)).To(gomega.BeTrue())
+
+}


### PR DESCRIPTION
While working on the virt-controller, I noticed that I needed much of the same core _itinerary_ logic.  Seemed reasonable to factor this out into common.

See the unit test for example/usage.