### PR TITLE
Add inventory Container.Replace().

### DIFF
--- a/pkg/inventory/container/ocp/collection.go
+++ b/pkg/inventory/container/ocp/collection.go
@@ -1,6 +1,7 @@
 package ocp
 
 import (
+	"context"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -14,7 +15,7 @@ type Collection interface {
 	// Get kubernetes resource object.
 	Object() runtime.Object
 	// Initial reconcile.
-	Reconcile() error
+	Reconcile(context.Context) error
 }
 
 //


### PR DESCRIPTION
Adds the Container.Replace() method to be more explicit.  It's important to support the replace within the container instead of the application (caller) doing a Delete() & Add() because the mutex prevents race conditions. 

Also, removed the `purge` parameter from Reconciler.Shutdown() because it was not being used and more appropriate (and symmetrical) to have the application (caller) completely mange the lifecycle of the DB.