### PR TITLE
Use cached client in OCP reconciler.

### DIFF
--- a/pkg/inventory/container/ocp/doc.go
+++ b/pkg/inventory/container/ocp/doc.go
@@ -1,0 +1,1 @@
+package ocp

--- a/pkg/inventory/container/ocp/reconciler.go
+++ b/pkg/inventory/container/ocp/reconciler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/konveyor/controller/pkg/ref"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -16,6 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"time"
+)
+
+const (
+	RetryDelay = time.Second * 5
 )
 
 //
@@ -36,12 +40,10 @@ type Reconciler struct {
 	db libmodel.DB
 	// Credentials secret.
 	secret *core.Secret
-	// Event logger.
-	log *logging.Logger
+	// Logger.
+	log logging.Logger
 	// Collections
 	collections []Collection
-	// The k8s client.
-	client client.Client
 	// The k8s manager.
 	manager manager.Manager
 	// The k8s manager/controller `stop` channel.
@@ -65,9 +67,9 @@ func New(
 	db libmodel.DB,
 	cluster Cluster,
 	secret *core.Secret,
-	log *logging.Logger,
 	collections ...Collection) *Reconciler {
 	//
+	log := logging.WithName(cluster.GetName())
 	return &Reconciler{
 		collections: collections,
 		cluster:     cluster,
@@ -98,7 +100,7 @@ func (r *Reconciler) DB() libmodel.DB {
 //
 // Get the Client.
 func (r *Reconciler) Client() client.Client {
-	return r.client
+	return r.manager.GetClient()
 }
 
 //
@@ -126,32 +128,74 @@ func (r *Reconciler) UpdateThreshold(m libmodel.Model) {
 
 //
 // Start the reconciler.
-func (r *Reconciler) Start() (err error) {
+func (r *Reconciler) Start() error {
+	ctx := context.Background()
+	ctx, r.cancel = context.WithCancel(ctx)
+	for _, collection := range r.collections {
+		collection.Bind(r)
+	}
+	start := func() {
+	try:
+		for {
+			select {
+			case <-ctx.Done():
+				break try
+			default:
+				err := r.start(ctx)
+				if err != nil {
+					r.log.Trace(err, "retry", RetryDelay)
+					time.Sleep(RetryDelay)
+					continue try
+				}
+				break try
+			}
+		}
+	}
+
+	go start()
+
+	return nil
+}
+
+//
+// Start details.
+//   1. Build and start the manager.
+//   2. Reconcile all of the collections.
+//   3. Mark consistent.
+//   4. Start apply events (coroutine).
+func (r *Reconciler) start(ctx context.Context) (err error) {
 	r.versionThreshold = 0
 	r.eventChannel = make(chan ModelEvent, 100)
 	r.stopChannel = make(chan struct{})
 	defer func() {
 		if err != nil {
-			close(r.stopChannel)
-			close(r.eventChannel)
+			r.terminate()
 		}
 	}()
-	for _, collection := range r.collections {
-		collection.Bind(r)
-	}
-	err = r.buildClient()
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
+	mark := time.Now()
+	r.log.Info("Start")
 	err = r.buildManager()
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
 	go r.manager.Start(r.stopChannel)
-	ctx := context.Background()
-	ctx, r.cancel = context.WithCancel(ctx)
+	err = r.reconcileCollections(ctx)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	go r.applyEvents()
+
+	r.log.Info("Started", "duration", time.Since(mark))
+
+	return
+}
+
+//
+// Reconcile collections.
+func (r *Reconciler) reconcileCollections(ctx context.Context) (err error) {
+	mark := time.Now()
 	for _, collection := range r.collections {
 		err = collection.Reconcile(ctx)
 		if err != nil {
@@ -159,21 +203,34 @@ func (r *Reconciler) Start() (err error) {
 			return
 		}
 	}
+
+	r.log.Info("Initial consistency.", "duration", time.Since(mark))
 	r.consistent = true
-	go r.applyEvents()
 
 	return
 }
 
 //
 // Shutdown the reconciler.
+//   1. Close manager stop channel.
+//   2. Close watch event coroutine channel.
+//   3. Cancel the context.
 func (r *Reconciler) Shutdown() {
-	r.log.Info("Shutdown", "name", r.Name())
-	close(r.stopChannel)
-	close(r.eventChannel)
+	r.log.Info("Shutdown")
+	r.terminate()
 	if r.cancel != nil {
 		r.cancel()
 	}
+}
+
+//
+// Terminate coroutines.
+func (r *Reconciler) terminate() {
+	defer func() {
+		recover()
+	}()
+	close(r.stopChannel)
+	close(r.eventChannel)
 }
 
 //
@@ -216,21 +273,6 @@ func (r *Reconciler) Delete(m libmodel.Model) {
 }
 
 //
-// Build k8s client.
-func (r *Reconciler) buildClient() (err error) {
-	r.client, err = client.New(
-		r.cluster.RestCfg(r.secret),
-		client.Options{
-			Scheme: scheme.Scheme,
-		})
-	if err != nil {
-		err = liberr.Wrap(err)
-	}
-
-	return
-}
-
-//
 // Build the k8s manager.
 func (r *Reconciler) buildManager() (err error) {
 	r.manager, err = manager.New(
@@ -269,6 +311,8 @@ func (r *Reconciler) buildManager() (err error) {
 //
 // Apply model events.
 func (r *Reconciler) applyEvents() {
+	r.log.Info("Apply - started")
+	defer r.log.Info("Apply - ended")
 	for event := range r.eventChannel {
 		err := event.Apply(r)
 		if err != nil {


### PR DESCRIPTION
Some OCP (data) reconciler improvements:
- use the regular cached client.  This eliminates a double connect.
- asynchronous Start().
- Shutdown() idempotent.