### PR TITLE
Errors must only be wrapped in context.

### DIFF
--- a/pkg/inventory/model/predicate.go
+++ b/pkg/inventory/model/predicate.go
@@ -144,7 +144,7 @@ type EqPredicate struct {
 func (p *EqPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	v, err := f.AsValue(p.Value)
 	if err != nil {
@@ -171,7 +171,7 @@ type NeqPredicate struct {
 func (p *NeqPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	v, err := f.AsValue(p.Value)
 	if err != nil {
@@ -198,7 +198,7 @@ type GtPredicate struct {
 func (p *GtPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	switch f.Value.Kind() {
 	case reflect.String,
@@ -237,7 +237,7 @@ type LtPredicate struct {
 func (p *LtPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	switch f.Value.Kind() {
 	case reflect.String,

--- a/pkg/itinerary/simple.go
+++ b/pkg/itinerary/simple.go
@@ -1,6 +1,9 @@
 package itinerary
 
-import liberr "github.com/konveyor/controller/pkg/error"
+import (
+	"errors"
+	liberr "github.com/konveyor/controller/pkg/error"
+)
 
 //
 // List of steps.
@@ -47,7 +50,7 @@ type Itinerary struct {
 //
 // Errors.
 var (
-	StepNotFound = liberr.New("step not found")
+	StepNotFound = errors.New("step not found")
 )
 
 //
@@ -59,7 +62,7 @@ func (r *Itinerary) Get(name string) (step Step, err error) {
 		}
 	}
 
-	err = StepNotFound
+	err = liberr.Wrap(StepNotFound)
 	return
 }
 
@@ -74,7 +77,7 @@ func (r *Itinerary) First() (step Step, err error) {
 	if len(list) > 0 {
 		step = list[0]
 	} else {
-		err = StepNotFound
+		err = liberr.Wrap(StepNotFound)
 	}
 
 	return


### PR DESCRIPTION
Errors must only be wrapped in context to capture the correct stack trace.