### PR TITLE
WIP: Fix vendor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -756,7 +756,7 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "e17681d19d3ac4837a019ece36c2a0ec31ffe985"
+  revision = "51747d6e00da1fc578d5a333a93bb2abcbce7a95"
 
 [[projects]]
   digest = "1:72fd56341405f53c745377e0ebc4abeff87f1a048e0eea6568a20212650f5a82"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -743,8 +743,7 @@
   version = "kubernetes-1.13.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:6dc0e912aaeea5f98199e018d3601b4c98b7549afd0cd5ef4ca025911e0a90b2"
+  digest = "1:13eb03444ca0aa569484b348417d8500282794c8de6588a67dc2c722516070d7"
   name = "k8s.io/gengo"
   packages = [
     "args",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,10 +27,6 @@ required = [
   version="=v0.1.10"
 
 [[constraint]]
-  name="sigs.k8s.io/controller-tools"
-  version="v0.1.1"
-
-[[constraint]]
   name = "github.com/go-logr/logr"
   version = "0.1.0"
 

--- a/vendor/k8s.io/gengo/parser/parse.go
+++ b/vendor/k8s.io/gengo/parser/parse.go
@@ -403,7 +403,7 @@ func (b *Builder) typeCheckPackage(pkgPath importPathString) (*tc.Package, error
 	}
 	parsedFiles, ok := b.parsed[pkgPath]
 	if !ok {
-		return nil, fmt.Errorf("No files for pkg %q", pkgPath)
+		return nil, fmt.Errorf("No files for pkg %q: %#v", pkgPath, b.parsed)
 	}
 	files := make([]*ast.File, len(parsedFiles))
 	for i := range parsedFiles {


### PR DESCRIPTION
k8s.io/code-generator wants k8s.io/gengo@master, 
k8s.io/gengo@master wants k8s.io/klog/v2,
k8s.io/klog/v2 moved to dep so it wont be seen by dep[[1]](https://github.com/kubernetes/utils/pull/152)

This pins the revision of gengo from [release-1.13](https://github.com/kubernetes/code-generator/commit/cb3d3f4c6fa2e2eeb6a07602786cf678413af380#diff-681659ab9abb4b4883e78e8aaa980dbaR123) deps

This also removes controller-tools, dep was complaining that the
package was not directly imported in which case we can remove it

For my dep version, I am able to run `dep ensure -v` again

```
Alays-MacBook-Pro-2:controller alay$ dep version
dep:
 version     : v0.5.4
 build date  : 2019-09-29
 git hash    : 1f7c19e
 go version  : go1.13
 go compiler : gc
 platform    : darwin/amd64
 features    : ImportDuringSolve=false
Alays-MacBook-Pro-2:controller alay$ git log -n 1
commit 527a4cff217e2030aa125efcade154fad58ee7a0 (HEAD -> fix-vendor, origin/fix-vendor)
Author: Alay Patel <alay1431@gmail.com>
Date:   Thu Sep 24 00:08:50 2020 -0400

    rerun dep ensure to change digest
Alays-MacBook-Pro-2:controller alay$ dep ensure -v
Alays-MacBook-Pro-2:controller alay$ 
```