### PR TITLE
Add Conditions.UpdateConditions()

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -189,6 +189,12 @@ func (r *Conditions) SetCondition(conditions ...Condition) {
 }
 
 //
+// Update conditions.
+func (r *Conditions) UpdateConditions(other Conditions) {
+	r.SetCondition(other.List...)
+}
+
+//
 // Stage an existing condition by type.
 func (r *Conditions) StageCondition(types ...string) {
 	if r.List == nil {


### PR DESCRIPTION
Add convenience method for aggregating conditions.

Also, go back to using non-cached client in the OCP reconciler.  I have observed race conditions when listing resources and when the cache is updated by watch.