### PR TITLE
Use int64 in progress object.

### DIFF
--- a/pkg/itinerary/simple.go
+++ b/pkg/itinerary/simple.go
@@ -143,7 +143,7 @@ func (r *Itinerary) Progress(step string) (report Progress, err error) {
 	if err != nil {
 		return
 	}
-	report.Total = len(list)
+	report.Total = int64(len(list))
 	for _, s := range list {
 		if s.Name != step {
 			report.Completed++
@@ -201,7 +201,7 @@ func (r *Itinerary) hasAll(step Step) (pTrue bool, err error) {
 // Progress report.
 type Progress struct {
 	// Completed units.
-	Completed int `json:"completed"`
+	Completed int64 `json:"completed"`
 	// Total units.
-	Total int `json:"total"`
+	Total int64 `json:"total"`
 }

--- a/pkg/itinerary/simple_test.go
+++ b/pkg/itinerary/simple_test.go
@@ -174,7 +174,7 @@ func TestProgress(t *testing.T) {
 	for i, step := range list {
 		report, err := itinerary.Progress(step.Name)
 		g.Expect(err).To(gomega.BeNil())
-		g.Expect(report.Total).To(gomega.Equal(len(list)))
-		g.Expect(report.Completed).To(gomega.Equal(i))
+		g.Expect(report.Total).To(gomega.Equal(int64(len(list))))
+		g.Expect(report.Completed).To(gomega.Equal(int64(i)))
 	}
 }


### PR DESCRIPTION
Use int64 in `Progress` object to accommodate broader use cases such as memory and storage capacity.