### PR TITLE
Enable TLS for inventory

### DIFF
--- a/pkg/inventory/web/web.go
+++ b/pkg/inventory/web/web.go
@@ -5,6 +5,8 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/controller/pkg/inventory/container"
+	"crypto/tls"
+	"net/http"
 	"regexp"
 	"time"
 )
@@ -14,6 +16,8 @@ const (
 	NsParam      = "ns1"
 	NsCollection = "namespaces"
 	Root         = "/" + NsCollection + "/:" + NsParam
+	TlsCert      = "/var/run/secrets/inventory-tls/tls.crt"
+	TlsKey   = "/var/run/secrets/inventory-tls/tls.key"
 )
 
 //
@@ -34,6 +38,7 @@ type WebServer struct {
 //
 // Start the web-server.
 // Initializes `gin` with routes and CORS origins.
+// Creates an http server to handle TLS
 func (w *WebServer) Start() {
 	router := gin.Default()
 	router.Use(cors.New(cors.Config{


### PR DESCRIPTION
This pull request enable TLS for the inventory container if the configuration provides TLS configuration.
The certificate and key are provided by a secret automatically generated by the openshift-service-serving-signer, so the CA certificate chain is mounted in every pod as `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`. The secret is mounted in a path based on the secret name.

More information on using service serving certificates is available at [OpenShift > Security and compliance > Configuring certificates > Securing service traffic using service serving certificate secrets](https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html).

The deployment, service and route are modified in [konveyor/virt-operator#29](https://github.com/konveyor/virt-operator/pull/29).