### PR TITLE
Disable metrics on remote manager in OCP (data) reconciler.

### DIFF
--- a/pkg/inventory/container/ocp/reconciler.go
+++ b/pkg/inventory/container/ocp/reconciler.go
@@ -285,7 +285,9 @@ func (r *Reconciler) Delete(m libmodel.Model) {
 func (r *Reconciler) buildManager() (err error) {
 	r.manager, err = manager.New(
 		r.cluster.RestCfg(r.secret),
-		manager.Options{})
+		manager.Options{
+			MetricsBindAddress: "0",
+		})
 	if err != nil {
 		err = liberr.Wrap(err)
 		return


### PR DESCRIPTION
Disable metrics on remote manager in OCP (data) reconciler to avoid port 8080 already in use error.

https://book-v1.book.kubebuilder.io/beyond_basics/controller_metrics.html
_Please note that metrics support has been added in controller-runtime 0.1.8+ release which is the default version for Kubebuilder 1.0.6+ releases. So if your project was created using 1.0.5 or older kubebuilder, then update the controller-runtime dependencies to 0.1.8 or higher._

https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L127