### PR TITLE
Model enhancements.

### DIFF
--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -13,6 +13,10 @@
 //       Unique index. `G` = unique-together fields.
 //   `sql:"const"`
 //       The field is immutable and not included on update.
+//   `sql:"virtual"`
+//       The field is read-only and managed internally by the DB.
+//   `sql:"dn"`
+//       The field detail level.  n = level number (0-9).
 // Each struct must implement the `Model` interface.
 // Basic CRUD operations may be performed on each model using
 // the `DB` interface which together with the `Model` interface


### PR DESCRIPTION
Model layer improvements.
- Add support for _virtual_ fields.  A _virtual_ field is a virtual field managed by the DB.  For sqlite3, this would be the `rowid`.
- Add support for json encoding of model fields that are type: `struct`, `slice`, `map`.
- Add support to specify detail level(s) when listing (query) models.

Both forklift (provider) and crane (discover) inventory services store json encoded structs in the DB.  This will eliminate a good bit of code.

For example: https://github.com/konveyor/forklift-controller/pull/134