### PR TITLE
Error support nested unwrap.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
 	go.uber.org/atomic v1.4.0 // indirect

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -3,6 +3,7 @@ package error
 import (
 	"errors"
 	"github.com/onsi/gomega"
+	errors2 "github.com/pkg/errors"
 	"testing"
 )
 
@@ -22,5 +23,23 @@ func TestError(t *testing.T) {
 	g.Expect(len(le2.stack)).To(gomega.Equal(4))
 	g.Expect(le2.Error()).To(gomega.Equal(err.Error()))
 
+	wrapped := errors2.Wrap(err, "help")
+	le3 := Wrap(wrapped).(*Error)
+	g.Expect(le3).NotTo(gomega.BeNil())
+	g.Expect(le3.wrapped).To(gomega.Equal(wrapped))
+	g.Expect(le3.wrapped).To(gomega.Equal(wrapped))
+	g.Expect(len(le3.stack)).To(gomega.Equal(4))
+	g.Expect(errors.Unwrap(le3)).To(gomega.Equal(err))
+
 	println(le.Stack())
+}
+
+func TestUnwrap(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	err := errors.New("failed")
+	g.Expect(err).To(gomega.Equal(Unwrap(err)))
+	g.Expect(Unwrap(nil)).To(gomega.BeNil())
+	g.Expect(Unwrap(Wrap(err))).To(gomega.Equal(err))
+	g.Expect(Unwrap(errors2.Wrap(err, ""))).To(gomega.Equal(err))
+	g.Expect(Unwrap(errors2.Wrap(errors2.Wrap(err, ""), ""))).To(gomega.Equal(err))
 }

--- a/pkg/error/wrap.go
+++ b/pkg/error/wrap.go
@@ -46,6 +46,25 @@ func Wrap(err error) error {
 }
 
 //
+// Unwrap an error.
+// Returns: the original error when not wrapped.
+func Unwrap(err error) (out error) {
+	if err == nil {
+		return
+	}
+	out = err
+	for {
+		if wrapped, cast := out.(interface{ Unwrap() error }); cast {
+			out = wrapped.Unwrap()
+		} else {
+			break
+		}
+	}
+
+	return
+}
+
+//
 // Error.
 // Wraps a root cause error and captures
 // the stack.
@@ -77,5 +96,5 @@ func (e Error) Stack() string {
 //
 // Unwrap the error.
 func (e Error) Unwrap() error {
-	return e.wrapped
+	return Unwrap(e.wrapped)
 }


### PR DESCRIPTION
Supported nested `Unwrap()`.
Needed for cases where an `Error` is created using `Wrap()` and passed an error (of another type) that is already wrapped.