### PR TITLE
Model: Journal improvements

### DIFF
--- a/pkg/inventory/model/model.go
+++ b/pkg/inventory/model/model.go
@@ -91,3 +91,18 @@ type Base struct {
 func (m *Base) Pk() string {
 	return m.PK
 }
+
+//
+// Create new the model.
+func Clone(model Model) Model {
+	mt := reflect.TypeOf(model)
+	mv := reflect.ValueOf(model)
+	switch mt.Kind() {
+	case reflect.Ptr:
+		mt = mt.Elem()
+		mv = mv.Elem()
+	}
+	new := reflect.New(mt).Elem()
+	new.Set(mv)
+	return new.Addr().Interface().(Model)
+}


### PR DESCRIPTION
Model journal improvements.
- **Removed concept of enabling/disabling the journal.**  Instead, the journal only records (stages) events when there is at least (1) watch for the model (kind).
- **Reduce the risk of initial `Created` events from exceeding the queue (channel) limit.**  This is accomplished by passing the list of existing models to the watch on `Start()` instead of writing them to the queue.  Subsequent (change) events should not exceed the queue limit.  However, in the unlikely event they do, the watch is notified using the `Watch.Error()` and the watch should be restarted.  