### PR TITLE
Add event handler started().

### DIFF
--- a/pkg/inventory/model/journal.go
+++ b/pkg/inventory/model/journal.go
@@ -29,6 +29,8 @@ type Event struct {
 //
 // Event handler.
 type EventHandler interface {
+	// Watch has started.
+	Started()
 	// A model has been created.
 	Created(Event)
 	// A model has been updated.
@@ -84,6 +86,7 @@ func (w *Watch) Start(list *reflect.Value) {
 	if w.started {
 		return
 	}
+	w.Handler.Started()
 	run := func() {
 		for i := 0; i < list.Len(); i++ {
 			m := list.Index(i).Addr().Interface()
@@ -248,3 +251,31 @@ func (r *Journal) hasWatch(model Model) bool {
 
 	return false
 }
+
+//
+// Stub event handler.
+type StubEventHandler struct{}
+
+//
+// Watch has started.
+func (r *StubEventHandler) Started() {}
+
+//
+// A model has been created.
+func (r *StubEventHandler) Created(Event) {}
+
+//
+// A model has been updated.
+func (r *StubEventHandler) Updated(Event) {}
+
+//
+// A model has been deleted.
+func (r *StubEventHandler) Deleted(Event) {}
+
+//
+// An error has occurred delivering an event.
+func (r *StubEventHandler) Error(error) {}
+
+//
+// An event watch has ended.
+func (r *StubEventHandler) End() {}

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -64,12 +64,17 @@ type TestEvent struct {
 
 type TestHandler struct {
 	name    string
+	started bool
 	all     []TestEvent
 	created []int
 	updated []int
 	deleted []int
 	err     []error
 	done    bool
+}
+
+func (w *TestHandler) Started() {
+	w.started = true
 }
 
 func (w *TestHandler) Created(e Event) {
@@ -102,8 +107,13 @@ func (w *TestHandler) End() {
 type MutatingHandler struct {
 	DB
 	name    string
+	started bool
 	created []int
 	updated []int
+}
+
+func (w *MutatingHandler) Started() {
+	w.started = true
 }
 
 func (w *MutatingHandler) Created(e Event) {
@@ -476,6 +486,9 @@ func TestWatch(t *testing.T) {
 			break
 		}
 	}
+	g.Expect(handlerA.started).To(gomega.BeTrue())
+	g.Expect(handlerB.started).To(gomega.BeTrue())
+	g.Expect(handlerC.started).To(gomega.BeTrue())
 	//
 	// The scenario is:
 	// 1. handler A created


### PR DESCRIPTION
Add support for the watch event handler to be notified when a watch has Started().  This provides the event handler an opportunity to do construction & initialization.

Add _stub_ watch event handler.  Support event handler only implementing methods for events it cares about.