### PR TITLE
Wrap errors only at the edge.

### DIFF
--- a/pkg/inventory/container/ocp/reconciler.go
+++ b/pkg/inventory/container/ocp/reconciler.go
@@ -184,18 +184,15 @@ func (r *Reconciler) start(ctx context.Context) (err error) {
 	r.log.Info("Start")
 	err = r.buildManager()
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	err = r.buildClient()
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	go r.manager.Start(r.stopChannel)
 	err = r.reconcileCollections(ctx)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	go r.applyEvents()
@@ -372,7 +369,6 @@ type ModelEvent struct {
 func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 	tx, err := rl.db.Begin()
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 	defer func() {
@@ -390,7 +386,6 @@ func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 			rl.log.Info("Create", ref.ToKind(r.model), r.model.String())
 			err = tx.Insert(r.model)
 			if err != nil {
-				err = liberr.Wrap(err)
 				return
 			}
 		}
@@ -399,7 +394,6 @@ func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 			rl.log.Info("Update", ref.ToKind(r.model), r.model.String())
 			err = tx.Update(r.model)
 			if err != nil {
-				err = liberr.Wrap(err)
 				return
 			}
 		}
@@ -407,7 +401,6 @@ func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 		rl.log.Info("Delete", ref.ToKind(r.model), r.model.String())
 		err = tx.Delete(r.model)
 		if err != nil {
-			err = liberr.Wrap(err)
 			return
 		}
 	default:
@@ -415,7 +408,6 @@ func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 	}
 	err = tx.Commit()
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
 

--- a/pkg/inventory/model/predicate.go
+++ b/pkg/inventory/model/predicate.go
@@ -163,7 +163,7 @@ func (p *SimplePredicate) build(operator string, options *ListOptions) error {
 	default:
 		v, err := f.AsValue(p.Value)
 		if err != nil {
-			return liberr.Wrap(err)
+			return err
 		}
 		p.expr = strings.Join(
 			[]string{
@@ -299,7 +299,7 @@ func (p *AndPredicate) Build(options *ListOptions) error {
 	for _, p := range p.Predicates {
 		err := p.Build(options)
 		if err != nil {
-			return liberr.Wrap(err)
+			return err
 		}
 	}
 
@@ -331,7 +331,7 @@ func (p *OrPredicate) Build(options *ListOptions) error {
 	for _, p := range p.Predicates {
 		err := p.Build(options)
 		if err != nil {
-			return liberr.Wrap(err)
+			return err
 		}
 	}
 

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -181,7 +181,7 @@ func (t Table) Validate(fields []*Field) error {
 	for _, f := range fields {
 		err := f.Validate()
 		if err != nil {
-			return liberr.Wrap(err)
+			return err
 		}
 	}
 	pk := t.PkField(fields)
@@ -199,11 +199,11 @@ func (t Table) DDL(model interface{}) ([]string, error) {
 	tpl := template.New("")
 	fields, err := t.Fields(model)
 	if err != nil {
-		return nil, liberr.Wrap(err)
+		return nil, err
 	}
 	err = t.Validate(fields)
 	if err != nil {
-		return nil, liberr.Wrap(err)
+		return nil, err
 	}
 	// Table
 	tpl, err = tpl.Parse(TableDDL)
@@ -252,12 +252,12 @@ func (t Table) DDL(model interface{}) ([]string, error) {
 func (t Table) Insert(model interface{}) error {
 	fields, err := t.Fields(model)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	t.SetPk(fields)
 	stmt, err := t.insertSQL(t.Name(model), fields)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	params := t.Params(fields)
 	r, err := t.DB.Exec(stmt, params...)
@@ -283,12 +283,12 @@ func (t Table) Insert(model interface{}) error {
 func (t Table) Update(model interface{}) error {
 	fields, err := t.Fields(model)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	t.SetPk(fields)
 	stmt, err := t.updateSQL(t.Name(model), fields)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	params := t.Params(fields)
 	r, err := t.DB.Exec(stmt, params...)
@@ -312,12 +312,12 @@ func (t Table) Update(model interface{}) error {
 func (t Table) Delete(model interface{}) error {
 	fields, err := t.Fields(model)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	t.SetPk(fields)
 	stmt, err := t.deleteSQL(t.Name(model), fields)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	params := t.Params(fields)
 	r, err := t.DB.Exec(stmt, params...)
@@ -342,12 +342,12 @@ func (t Table) Delete(model interface{}) error {
 func (t Table) Get(model interface{}) error {
 	fields, err := t.Fields(model)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	t.SetPk(fields)
 	stmt, err := t.getSQL(t.Name(model), fields)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	params := t.Params(fields)
 	row := t.DB.QueryRow(stmt, params...)
@@ -378,11 +378,11 @@ func (t Table) List(list interface{}, options ListOptions) error {
 	}
 	fields, err := t.Fields(model)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	stmt, err := t.listSQL(t.Name(model), fields, &options)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 	params := options.Params()
 	cursor, err := t.DB.Query(stmt, params...)
@@ -417,19 +417,16 @@ func (t Table) List(list interface{}, options ListOptions) error {
 func (t Table) Count(model interface{}, predicate Predicate) (int64, error) {
 	fields, err := t.Fields(model)
 	if err != nil {
-		return 0, liberr.Wrap(err)
+		return 0, err
 	}
 	options := ListOptions{Predicate: predicate}
 	stmt, err := t.countSQL(t.Name(model), fields, &options)
 	if err != nil {
-		return 0, liberr.Wrap(err)
+		return 0, err
 	}
 	count := int64(0)
 	params := options.Params()
 	row := t.DB.QueryRow(stmt, params...)
-	if err != nil {
-		return 0, liberr.Wrap(err)
-	}
 	err = row.Scan(&count)
 	if err != nil {
 		return 0, liberr.Wrap(err)
@@ -740,7 +737,7 @@ func (t Table) listSQL(table string, fields []*Field, options *ListOptions) (str
 	}
 	err = options.Build(table, fields)
 	if err != nil {
-		return "", liberr.Wrap(err)
+		return "", err
 	}
 	bfr := &bytes.Buffer{}
 	err = tpl.Execute(
@@ -768,7 +765,7 @@ func (t Table) countSQL(table string, fields []*Field, options *ListOptions) (st
 	}
 	err = options.Build(table, fields)
 	if err != nil {
-		return "", liberr.Wrap(err)
+		return "", err
 	}
 	bfr := &bytes.Buffer{}
 	err = tpl.Execute(
@@ -1313,7 +1310,7 @@ func (l *ListOptions) Build(table string, fields []*Field) error {
 	}
 	err := l.Predicate.Build(l)
 	if err != nil {
-		return liberr.Wrap(err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The original philosophy was the by wrapping errors at all levels would:
- Ensure errors got wrapped.
- Easier to code review because it's consistent.
After living with it for a while it seem apparent that neither are true.  Wrapping only where errors are returned by external packages is:
- reliable
- straight forward to code review
- reduces code noise. 