### PR TITLE
Add support for watch in web layer.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
-	github.com/gorilla/websocket v1.4.0
+	github.com/gorilla/websocket v1.4.2
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/gorilla/websocket v1.4.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/pkg/inventory/model/client.go
+++ b/pkg/inventory/model/client.go
@@ -234,7 +234,7 @@ func (r *Client) Watch(model Model, handler EventHandler) (*Watch, error) {
 		return nil, err
 	}
 	list := listPtr.Elem()
-	watch.Start(&list)
+	watch.start(&list)
 
 	return watch, nil
 }

--- a/pkg/inventory/web/client.go
+++ b/pkg/inventory/web/client.go
@@ -1,0 +1,302 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/gorilla/websocket"
+	liberr "github.com/konveyor/controller/pkg/error"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"io/ioutil"
+	"net/http"
+	liburl "net/url"
+	"reflect"
+	"time"
+)
+
+//
+// Header.
+const (
+	WatchHeader = "X-Watch"
+)
+
+//
+// Event handler
+type EventHandler interface {
+	// The watch has started.
+	Started()
+	// Parity marker.
+	// The watch has delivered the initial set
+	// of `Created` events.
+	Parity()
+	// Resource created.
+	Created(r Event)
+	// Resource updated.
+	Updated(r Event)
+	// Resource deleted.
+	Deleted(r Event)
+	// An error has occurred.
+	Error(error)
+	// The watch has ended.
+	End()
+}
+
+//
+// REST client.
+type Client struct {
+	// Transport.
+	Transport http.RoundTripper
+	// Headers.
+	Header http.Header
+}
+
+//
+// HTTP GET (method).
+func (r *Client) Get(url string, out interface{}) (status int, err error) {
+	parsedURL, err := liburl.Parse(url)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	request := &http.Request{
+		Header: r.Header,
+		Method: http.MethodGet,
+		URL:    parsedURL,
+	}
+	client := http.Client{Transport: r.Transport}
+	response, err := client.Do(request)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	status = response.StatusCode
+	content := []byte{}
+	if status == http.StatusOK {
+		defer func() {
+			_ = response.Body.Close()
+		}()
+		content, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		err = json.Unmarshal(content, out)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+	}
+
+	return
+}
+
+//
+// HTTP POST (method).
+func (r *Client) Post(url string, in interface{}, out interface{}) (status int, err error) {
+	parsedURL, err := liburl.Parse(url)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	body, _ := json.Marshal(in)
+	reader := bytes.NewReader(body)
+	request := &http.Request{
+		Header: r.Header,
+		Method: http.MethodPost,
+		Body:   ioutil.NopCloser(reader),
+		URL:    parsedURL,
+	}
+	client := http.Client{Transport: r.Transport}
+	response, err := client.Do(request)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	status = response.StatusCode
+	content := []byte{}
+	if status == http.StatusOK {
+		defer func() {
+			_ = response.Body.Close()
+		}()
+		if out == nil {
+			return
+		}
+		content, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		err = json.Unmarshal(content, out)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+	}
+
+	return
+}
+
+//
+// Watch a resource.
+func (r *Client) Watch(
+	url string,
+	resource interface{},
+	handler EventHandler) (status int, w *Watch, err error) {
+	//
+	url = r.patchURL(url)
+	dialer := websocket.DefaultDialer
+	post := func(w *WatchReader) (pStatus int, pErr error) {
+		socket, response, pErr := dialer.Dial(
+			url, http.Header{
+				WatchHeader: []string{"1"},
+			})
+		if pErr != nil {
+			pErr = liberr.Wrap(pErr)
+			return
+		}
+		pStatus = response.StatusCode
+		switch pStatus {
+		case http.StatusOK,
+			http.StatusSwitchingProtocols:
+			pStatus = http.StatusOK
+			w.webSocket = socket
+		}
+		return
+	}
+	reader := &WatchReader{
+		resource: resource,
+		handler:  handler,
+		repair:   post,
+	}
+	status, err = post(reader)
+	if err != nil || status != http.StatusOK {
+		return
+	}
+
+	w = &Watch{reader: reader}
+	reader.start()
+
+	return
+}
+
+//
+// Patch the URL.
+func (r *Client) patchURL(in string) (out string) {
+	out = in
+	url, err := liburl.Parse(in)
+	if err != nil {
+		return
+	}
+	switch url.Scheme {
+	case "http":
+		url.Scheme = "ws"
+	case "https":
+		url.Scheme = "wss"
+	default:
+		return
+	}
+
+	out = url.String()
+
+	return
+}
+
+//
+// Watch (event) reader.
+type WatchReader struct {
+	// Repair function.
+	repair func(*WatchReader) (int, error)
+	// Web socket.
+	webSocket *websocket.Conn
+	// Web resource.
+	resource interface{}
+	// Event handler.
+	handler EventHandler
+	// Started.
+	started bool
+	// Done.
+	done bool
+}
+
+//
+// Dispatch events.
+func (r *WatchReader) start() {
+	if r.started {
+		return
+	}
+	r.started = true
+	r.done = false
+	go func() {
+		defer func() {
+			_ = r.webSocket.Close()
+		}()
+		r.handler.Started()
+		for {
+			event := Event{
+				Resource: r.clone(r.resource),
+				Updated:  r.clone(r.resource),
+			}
+			err := r.webSocket.ReadJSON(&event)
+			if err != nil {
+				if r.done {
+					break
+				}
+				r.handler.Error(err)
+				for {
+					time.Sleep(time.Second * 10)
+					status, err := r.repair(r)
+					if err != nil || status != http.StatusOK {
+						r.handler.Error(err)
+					} else {
+						break
+					}
+				}
+			}
+			switch event.Action {
+			case libmodel.Parity:
+				r.handler.Parity()
+			case libmodel.Created:
+				r.handler.Created(event)
+			case libmodel.Updated:
+				r.handler.Updated(event)
+			case libmodel.Deleted:
+				r.handler.Deleted(event)
+			}
+		}
+		r.started = false
+		r.handler.End()
+	}()
+}
+
+//
+// Clone resource.
+func (r *WatchReader) clone(in interface{}) (out interface{}) {
+	mt := reflect.TypeOf(in)
+	mv := reflect.ValueOf(in)
+	switch mt.Kind() {
+	case reflect.Ptr:
+		mt = mt.Elem()
+		mv = mv.Elem()
+	}
+	new := reflect.New(mt).Elem()
+	new.Set(mv)
+	return new.Addr().Interface()
+}
+
+//
+// Terminate.
+func (r *WatchReader) terminate() {
+	r.done = true
+	_ = r.webSocket.Close()
+}
+
+//
+// Represents a watch.
+type Watch struct {
+	reader *WatchReader
+}
+
+//
+// End the watch.
+func (r *Watch) End() {
+	r.reader.terminate()
+}

--- a/pkg/inventory/web/handler.go
+++ b/pkg/inventory/web/handler.go
@@ -2,6 +2,8 @@ package web
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/controller/pkg/inventory/container"
 	"github.com/konveyor/controller/pkg/inventory/model"
 	"net/http"
@@ -118,6 +120,133 @@ func (h *Authorized) setToken(ctx *gin.Context) {
 	if len(fields) == 2 && fields[0] == "Bearer" {
 		h.Token = fields[1]
 	}
+}
+
+//
+// Watched resource builder.
+type ResourceBuilder func(model.Model) interface{}
+
+//
+// Event
+type Event struct {
+	// Action.
+	Action int8
+	// Affected Resource.
+	Resource interface{}
+	// Updated resource.
+	Updated interface{}
+}
+
+//
+// Watch (event) writer.
+type WatchWriter struct {
+	// negotiated web socket.
+	webSocket *websocket.Conn
+	// model watch.
+	watch *model.Watch
+	// Resource.
+	builder ResourceBuilder
+}
+
+//
+// End.
+func (r *WatchWriter) end() {
+	_ = r.webSocket.Close()
+	r.watch.End()
+}
+
+//
+// Write event to the socket.
+func (r *WatchWriter) send(e model.Event) {
+	event := Event{
+		Action: e.Action,
+	}
+	if e.Model != nil {
+		event.Resource = r.builder(e.Model)
+	}
+	if e.Updated != nil {
+		event.Updated = r.builder(e.Updated)
+	}
+	err := r.webSocket.WriteJSON(event)
+	if err != nil {
+		r.end()
+	}
+}
+
+//
+// Watch has started.
+func (r *WatchWriter) Started() {
+}
+
+//
+// Watch has parity.
+func (r *WatchWriter) Parity() {
+	r.send(model.Event{})
+}
+
+//
+// A model has been created.
+func (r *WatchWriter) Created(event model.Event) {
+	r.send(event)
+}
+
+//
+// A model has been updated.
+func (r *WatchWriter) Updated(event model.Event) {
+	r.send(event)
+}
+
+//
+// A model has been deleted.
+func (r *WatchWriter) Deleted(event model.Event) {
+	r.send(event)
+}
+
+//
+// An error has occurred delivering an event.
+func (r *WatchWriter) Error(err error) {
+}
+
+//
+// An event watch has ended.
+func (r *WatchWriter) End() {
+}
+
+//
+// Watched (handler).
+type Watched struct {
+	WatchRequest bool
+}
+
+//
+// Prepare the handler to fulfil the request.
+// Set the `HasWatch` field using passed headers.
+func (h *Watched) Prepare(ctx *gin.Context) int {
+	_, h.WatchRequest = ctx.Request.Header[WatchHeader]
+	return http.StatusOK
+}
+
+//
+// Watch model.
+func (r *Watched) Watch(
+	ctx *gin.Context,
+	db model.DB,
+	m model.Model,
+	rb ResourceBuilder) (err error) {
+	//
+	upGrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}
+	writer := &WatchWriter{builder: rb}
+	socket, err := upGrader.Upgrade(ctx.Writer, ctx.Request, nil)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	writer.webSocket = socket
+	writer.watch, err = db.Watch(m, writer)
+	return
 }
 
 //


### PR DESCRIPTION
Add support for watch in web layer.
This includes tools for the web (endpoint) _handler_.
Extensions to the web client.

Model <- (model)watch <- endpoint <- (resource)watch  [websocket] <- client

---
Loosely related:
Adds _Parity()_ event to the model event handler.
Adds Watch.End() for ending a watch for symmetry with web layer `Watch`.
Adds _Get()_ and _Post()_ to _base_ client.  Reduces code duplication in concrete clients.