### PR TITLE
Add support for user provided context in error.Wrap().

### DIFF
--- a/pkg/error/doc.go
+++ b/pkg/error/doc.go
@@ -1,0 +1,28 @@
+/*
+The error package provides practical wrap/unwrap features.
+The Wrap() function will capture caller provided and the captured stack.
+The stack is captured only on the first call to Wrap().
+Subsequent calls to Wrap() will augment the description and key/value
+pair context only.  Wrap() may safely be called with `nil`.
+The Unwrap() function will provide the original wrapped error.
+The New() function will create a new, wrapped error.
+
+Example:
+
+//
+// Simple Wrap/Unwrap.
+a := errors.New("No route to host").
+b := Wrap(a)
+c = Unwrap(b)  // a == c
+
+//
+// Wrap with context.
+url := "http://host/..."
+d := e1.Wrap(
+    a, "Web request failed."
+    "url", url)
+
+d.Error()   // "Web request failed. caused by: 'No route to host'"
+d.Context() // []string{"url", "http://host/..."}
+*/
+package error

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -16,6 +16,7 @@ func TestError(t *testing.T) {
 	g.Expect(le.wrapped).To(gomega.Equal(err))
 	g.Expect(len(le.stack)).To(gomega.Equal(4))
 	g.Expect(le.Error()).To(gomega.Equal(err.Error()))
+	g.Expect(le.Context()).To(gomega.BeNil())
 
 	le2 := Wrap(err).(*Error)
 	g.Expect(le2).NotTo(gomega.BeNil())
@@ -30,6 +31,26 @@ func TestError(t *testing.T) {
 	g.Expect(le3.wrapped).To(gomega.Equal(wrapped))
 	g.Expect(len(le3.stack)).To(gomega.Equal(4))
 	g.Expect(errors.Unwrap(le3)).To(gomega.Equal(err))
+	g.Expect(len(le3.Context())).To(gomega.Equal(0))
+	g.Expect(le3.Error()).To(gomega.Equal("help: failed"))
+
+	le4 := Wrap(
+		le3, "Failed to create user.",
+		"name", "larry",
+		"age", 10)
+	g.Expect(le4.(*Error).Error()).To(
+		gomega.Equal("Failed to create user. caused by: 'help: failed'"))
+	g.Expect(le4.(*Error).Context()).ToNot(gomega.BeNil())
+	g.Expect(len(le4.(*Error).Context())).To(gomega.Equal(4))
+
+	le5 := Wrap(
+		le4, "Web POST failed.",
+		"a", "A",
+		"b", "B")
+	g.Expect(le5.(*Error).Error()).To(
+		gomega.Equal("Web POST failed. caused by: 'Failed to create user.' caused by: 'help: failed'"))
+	g.Expect(le5.(*Error).Context()).ToNot(gomega.BeNil())
+	g.Expect(len(le5.(*Error).Context())).To(gomega.Equal(8))
 
 	println(le.Stack())
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -71,12 +71,19 @@ func (l Logger) Error(err error, message string, kvpair ...interface{}) {
 		if k8serr.IsConflict(err) {
 			return
 		}
+		if context := le.Context(); context != nil {
+			context = append(
+				context,
+				kvpair...)
+			kvpair = context
+		}
 		kvpair = append(
 			kvpair,
 			Error,
 			le.Error(),
 			Stack,
 			le.Stack())
+
 		l.Real.Info(message, kvpair...)
 		return
 	}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -96,4 +96,25 @@ func TestLogger(t *testing.T) {
 	g.Expect(len(f.entry[4].kvpair)).To(gomega.Equal(4))
 	g.Expect(f.entry[4].kvpair[0]).To(gomega.Equal(Error))
 	g.Expect(f.entry[4].kvpair[2]).To(gomega.Equal(Stack))
+	// Trace (wrapped) with context.
+	log.Trace(
+		liberr.Wrap(
+			errors.New("D wrapped"),
+			"Failed to create user.",
+			"name", "larry",
+			"age", 10),
+		"a", "A",
+		"b", "B")
+	g.Expect(len(f.entry)).To(gomega.Equal(6))
+	g.Expect(len(f.entry[5].kvpair)).To(gomega.Equal(12))
+	g.Expect(f.entry[5].kvpair[0]).To(gomega.Equal("name"))
+	g.Expect(f.entry[5].kvpair[1]).To(gomega.Equal("larry"))
+	g.Expect(f.entry[5].kvpair[2]).To(gomega.Equal("age"))
+	g.Expect(f.entry[5].kvpair[3]).To(gomega.Equal(10))
+	g.Expect(f.entry[5].kvpair[4]).To(gomega.Equal("a"))
+	g.Expect(f.entry[5].kvpair[5]).To(gomega.Equal("A"))
+	g.Expect(f.entry[5].kvpair[6]).To(gomega.Equal("b"))
+	g.Expect(f.entry[5].kvpair[7]).To(gomega.Equal("B"))
+	g.Expect(f.entry[5].kvpair[8]).To(gomega.Equal(Error))
+	g.Expect(f.entry[5].kvpair[10]).To(gomega.Equal(Stack))
 }


### PR DESCRIPTION
Add support for user provided context in error.Wrap().

Update the `logging` package to incorporate the context when logging.  Logger.Error() will append `Error.Context()` key/value pairs to those included in the call.