### PR TITLE
Fix detail=1 in initial CREATED watch listing.

### DIFF
--- a/pkg/inventory/model/client.go
+++ b/pkg/inventory/model/client.go
@@ -229,7 +229,9 @@ func (r *Client) Watch(model Model, handler EventHandler) (*Watch, error) {
 		return nil, err
 	}
 	listPtr := reflect.New(reflect.SliceOf(mt))
-	err = Table{r.db}.List(listPtr.Interface(), ListOptions{})
+	err = Table{r.db}.List(
+		listPtr.Interface(),
+		ListOptions{Detail: 1})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -488,6 +488,7 @@ func TestWatch(t *testing.T) {
 		object := &TestObject{
 			ID:   i,
 			Name: "Elmer",
+			D4:   "d4",
 		}
 		err = DB.Insert(object)
 		g.Expect(err).To(gomega.BeNil())


### PR DESCRIPTION
The _initial_ listing needs to have detail level (1) to include all fields.