### PR TITLE
Web authorization updates.

### DIFF
--- a/pkg/inventory/web/client.go
+++ b/pkg/inventory/web/client.go
@@ -179,11 +179,14 @@ func (r *Client) Watch(
 	//
 	url = r.patchURL(url)
 	dialer := websocket.DefaultDialer
+	header := http.Header{
+		WatchHeader: []string{"1"},
+	}
+	for k, v := range r.Header {
+		header[k] = v
+	}
 	post := func(w *WatchReader) (pStatus int, pErr error) {
-		socket, response, pErr := dialer.Dial(
-			url, http.Header{
-				WatchHeader: []string{"1"},
-			})
+		socket, response, pErr := dialer.Dial(url, header)
 		if pErr != nil {
 			pErr = liberr.Wrap(pErr)
 			return

--- a/pkg/inventory/web/handler.go
+++ b/pkg/inventory/web/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/konveyor/controller/pkg/inventory/model"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -95,31 +94,6 @@ func (c *Parity) EnsureParity(r container.Reconciler, w time.Duration) int {
 	}
 
 	return http.StatusPartialContent
-}
-
-//
-// Authorized by k8s bearer token.
-type Authorized struct {
-	// Bearer token.
-	Token string
-}
-
-//
-// Prepare the handler to fulfil the request.
-// Set the `token` field using passed parameters.
-func (h *Authorized) Prepare(ctx *gin.Context) int {
-	h.setToken(ctx)
-	return http.StatusOK
-}
-
-//
-// Set the `Token` field.
-func (h *Authorized) setToken(ctx *gin.Context) {
-	header := ctx.GetHeader("Authorization")
-	fields := strings.Fields(header)
-	if len(fields) == 2 && fields[0] == "Bearer" {
-		h.Token = fields[1]
-	}
 }
 
 //


### PR DESCRIPTION
Fix building watch header.  Header needs to be composed of the X-Watch header and existing headers (like the _Authorization_ header).
`Authorized` handler base removed.  No longer used.