### PR TITLE
File-based collections.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.1.2 // indirect
+	github.com/google/uuid v1.1.2
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/pkg/filebacked/catalog.go
+++ b/pkg/filebacked/catalog.go
@@ -1,0 +1,61 @@
+package filebacked
+
+import (
+	"reflect"
+	"sync"
+)
+
+//
+// Catalog (singleton).
+var catalog = Catalog{}
+
+//
+// Type catalog.
+type Catalog struct {
+	sync.Mutex
+	content []interface{}
+}
+
+//
+// Add object (proto) to the catalog.
+func (r *Catalog) add(object interface{}) (kind uint16) {
+	if object == nil {
+		return
+	}
+	r.Lock()
+	defer r.Unlock()
+	ot := reflect.TypeOf(object)
+	ov := reflect.ValueOf(object)
+	if reflect.TypeOf(object).Kind() == reflect.Ptr {
+		ot = ot.Elem()
+		ov = ov.Elem()
+	}
+	// Found.
+	for k, f := range r.content {
+		if ot == reflect.TypeOf(f) {
+			kind = uint16(k)
+			return
+		}
+	}
+	// Added.
+	kind = uint16(len(r.content))
+	r.content = append(r.content, ov.Interface())
+
+	return
+}
+
+//
+// Build object using the catalog.
+func (r *Catalog) build(kind uint16) (object interface{}, found bool) {
+	r.Lock()
+	defer r.Unlock()
+	content := r.content
+	i := int(kind)
+	if i < len(content) {
+		object = content[i]
+		object = reflect.New(reflect.TypeOf(object)).Interface()
+		found = true
+	}
+
+	return
+}

--- a/pkg/filebacked/doc.go
+++ b/pkg/filebacked/doc.go
@@ -1,0 +1,4 @@
+/*
+Provides file-backed collections.
+*/
+package filebacked

--- a/pkg/filebacked/file.go
+++ b/pkg/filebacked/file.go
@@ -1,0 +1,403 @@
+/*
+File backing for collections.
+File format:
+   Length: 8 (uint64)
+   | kind: 2 (uint16)
+   | size: 8 (uint64)
+   | object: n (gob encoded)
+   | ...
+*/
+package filebacked
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
+	"github.com/google/uuid"
+	liberr "github.com/konveyor/controller/pkg/error"
+	"io"
+	"os"
+	pathlib "path"
+)
+
+//
+// File extension.
+const (
+	Extension = ".fb"
+)
+
+//
+// Working Directory.
+var WorkingDir = "/tmp"
+
+//
+// Writer.
+type Writer struct {
+	// File path.
+	path string
+	// File.
+	file *os.File
+	// Number of objects written.
+	length uint64
+}
+
+//
+// Append (write) object.
+func (w *Writer) Append(object interface{}) (err error) {
+	// Lazy open.
+	err = w.open()
+	if err != nil {
+		return
+	}
+	// Update catalog.
+	kind := catalog.add(object)
+	// Encode object.
+	var bfr bytes.Buffer
+	encoder := gob.NewEncoder(&bfr)
+	err = encoder.Encode(object)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	// Write entry.
+	err = w.writeEntry(kind, bfr)
+
+	return
+}
+
+//
+// Get a reader.
+func (w *Writer) Reader() (reader *Reader) {
+	path := w.newPath()
+	err := w.file.Sync()
+	if err == nil {
+		err = os.Link(w.path, path)
+	}
+	reader = &Reader{
+		error: liberr.Wrap(err),
+		path:  path,
+	}
+
+	return
+}
+
+//
+// Close the writer.
+func (w *Writer) Close() {
+	if w.file != nil {
+		_ = w.file.Close()
+		_ = os.Remove(w.path)
+		w.file = nil
+	}
+}
+
+//
+// Open the writer.
+func (w *Writer) open() (err error) {
+	if w.file != nil {
+		return
+	}
+	w.path = w.newPath()
+	w.file, err = os.Create(w.path)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	err = w.writeLength()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+//
+// Write entry.
+func (w *Writer) writeEntry(kind uint16, bfr bytes.Buffer) (err error) {
+	file := w.file
+	// Write object kind.
+	b := make([]byte, 2)
+	binary.LittleEndian.PutUint16(b, kind)
+	_, err = file.Write(b)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	// Write object encoded length.
+	n := bfr.Len()
+	b = make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, uint64(n))
+	_, err = file.Write(b)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	// Write encoded object.
+	nWrite, err := file.Write(bfr.Bytes())
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if n != nWrite {
+		err = liberr.New("Write failed.")
+	}
+	// Write length.
+	w.length++
+	err = w.writeLength()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+//
+// Write length.
+// Number of objects written.
+func (w *Writer) writeLength() (err error) {
+	_, err = w.file.Seek(0, io.SeekStart)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, w.length)
+	_, err = w.file.Write(b)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	_, err = w.file.Seek(0, io.SeekEnd)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+//
+// New path.
+func (w *Writer) newPath() string {
+	uid, _ := uuid.NewUUID()
+	name := uid.String() + Extension
+	return pathlib.Join(WorkingDir, name)
+}
+
+//
+// Reader.
+type Reader struct {
+	// Error
+	error error
+	// File path.
+	path string
+	// File.
+	file *os.File
+}
+
+//
+// Length.
+// Number of objects in the list.
+func (r *Reader) Len() (length int) {
+	// Lazy open.
+	err := r.open()
+	if err != nil {
+		return
+	}
+	n, _ := r.len()
+	length = int(n)
+	return
+}
+
+//
+// Error.
+func (r *Reader) Error() error {
+	return r.error
+}
+
+//
+// Get the next object.
+func (r *Reader) NextWith(object interface{}) (hasNext bool, err error) {
+	if r.error != nil {
+		return
+	}
+	defer func() {
+		r.error = err
+	}()
+	// Lazy open.
+	err = r.open()
+	if err != nil {
+		return
+	}
+	// Read entry.
+	hasNext, _, b, err := r.readEntry()
+	if !hasNext || err != nil {
+		return
+	}
+	// Decode object.
+	bfr := bytes.NewBuffer(b)
+	decoder := gob.NewDecoder(bfr)
+	err = decoder.Decode(object)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+//
+// Get the next object.
+func (r *Reader) Next() (object interface{}, hasNext bool, err error) {
+	if r.error != nil {
+		return
+	}
+	defer func() {
+		r.error = err
+	}()
+	// Lazy open.
+	err = r.open()
+	if err != nil {
+		return
+	}
+	// Read entry.
+	hasNext, kind, b, err := r.readEntry()
+	if !hasNext || err != nil {
+		return
+	}
+	// Decode object.
+	bfr := bytes.NewBuffer(b)
+	decoder := gob.NewDecoder(bfr)
+	object, found := catalog.build(kind)
+	if !found {
+		err = liberr.New("kind not found in the catalog.")
+		return
+	}
+	err = decoder.Decode(object)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+//
+// Read next entry.
+func (r *Reader) readEntry() (hasNext bool, kind uint16, bfr []byte, err error) {
+	file := r.file
+	// Read object kind.
+	b := make([]byte, 2)
+	_, err = file.Read(b)
+	if err != nil {
+		if err != io.EOF {
+			err = liberr.Wrap(err)
+		} else {
+			err = nil
+		}
+		return
+	}
+	kind = binary.LittleEndian.Uint16(b)
+	// Read object encoded length.
+	b = make([]byte, 8)
+	_, err = file.Read(b)
+	if err != nil {
+		if err != io.EOF {
+			err = liberr.Wrap(err)
+		} else {
+			err = nil
+		}
+		return
+	}
+	n := int64(binary.LittleEndian.Uint64(b))
+	// Read encoded object.
+	b = make([]byte, n)
+	_, err = file.Read(b)
+	if err != nil {
+		if err != io.EOF {
+			err = liberr.Wrap(err)
+		} else {
+			err = nil
+		}
+		return
+	}
+
+	hasNext = true
+	bfr = b
+
+	return
+}
+
+//
+// Open the reader.
+func (r *Reader) open() (err error) {
+	if r.file != nil {
+		return
+	}
+	// Open.
+	r.file, err = os.Open(r.path)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	// Skip past length.
+	_, err = r.file.Seek(8, io.SeekStart)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+//
+// Close the reader.
+func (r *Reader) Close() {
+	if r.file != nil {
+		_ = r.file.Close()
+		_ = os.Remove(r.path)
+		r.file = nil
+	}
+}
+
+//
+// Read length.
+// Number of objects.
+func (r *Reader) len() (length uint64, err error) {
+	file := r.file
+	// Note current position.
+	offset, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	defer func() {
+		_, err = file.Seek(offset, io.SeekStart)
+		if err != nil {
+			err = liberr.Wrap(err)
+		}
+	}()
+	// Seek to beginning of the file.
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	// Read length.
+	b := make([]byte, 8)
+	_, err = file.Read(b)
+	if err != nil {
+		if err != io.EOF {
+			err = liberr.Wrap(err)
+		} else {
+			err = nil
+		}
+		return
+	}
+
+	length = binary.LittleEndian.Uint64(b)
+
+	return
+}

--- a/pkg/filebacked/iterator.go
+++ b/pkg/filebacked/iterator.go
@@ -1,0 +1,50 @@
+package filebacked
+
+//
+// Iterator.
+type Iterator interface {
+	// Length.
+	Len() int
+	// Next object.
+	Next() (interface{}, bool, error)
+	// Next object.
+	NextWith(object interface{}) (bool, error)
+	// Get associated error.
+	Error() error
+	// Close the iterator.
+	Close()
+}
+
+//
+// Empty.
+type EmptyIterator struct {
+}
+
+//
+// Length.
+func (*EmptyIterator) Len() int {
+	return 0
+}
+
+//
+// Next object.
+func (*EmptyIterator) Next() (interface{}, bool, error) {
+	return nil, false, nil
+}
+
+//
+// Next object.
+func (*EmptyIterator) NextWith(object interface{}) (bool, error) {
+	return false, nil
+}
+
+//
+// Get associated error.
+func (*EmptyIterator) Error() error {
+	return nil
+}
+
+//
+// Close the iterator.
+func (*EmptyIterator) Close() {
+}

--- a/pkg/filebacked/list.go
+++ b/pkg/filebacked/list.go
@@ -1,0 +1,75 @@
+/*
+Provides file-backed list.
+
+//
+// New list.
+list := fb.List{}
+defer list.Close()
+
+//
+// Append an object.
+err := list.Append(object)
+
+//
+// Iterate the list.
+itr := list.Iter()
+defer itr.Close()
+for {
+    object, hasNext, err := itr.Next()
+    if err != nil || !hasNext {
+        break
+    }
+}
+
+//
+// Iterate the list.
+itr := list.Iter()
+defer itr.Close()
+for {
+    person := Person{}
+    hasNext, err := itr.NextWith(&person))
+    if err != nil || !hasNext {
+        break
+    }
+}
+*/
+package filebacked
+
+//
+// File-backed list.
+type List struct {
+	// File writer.
+	writer Writer
+}
+
+//
+// Append an object.
+func (l *List) Append(object interface{}) (err error) {
+	err = l.writer.Append(object)
+	return
+}
+
+//
+// Length.
+// Number of objects.
+func (l *List) Len() int {
+	return int(l.writer.length)
+}
+
+//
+// Get an iterator.
+func (l *List) Iter() (itr Iterator) {
+	if l.Len() > 0 {
+		itr = l.writer.Reader()
+	} else {
+		itr = &EmptyIterator{}
+	}
+
+	return
+}
+
+//
+// Close (delete) the list.
+func (l *List) Close() {
+	l.writer.Close()
+}

--- a/pkg/filebacked/list_test.go
+++ b/pkg/filebacked/list_test.go
@@ -1,0 +1,119 @@
+package filebacked
+
+import (
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestList(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	type Ref struct {
+		ID string
+	}
+
+	type Person struct {
+		ID   int
+		Name string
+		Age  int
+		List []string
+		Ref  []Ref
+	}
+
+	type User struct {
+		ID   int
+		Name string
+	}
+
+	input := []interface{}{}
+	for i := 0; i < 10; i++ {
+		input = append(
+			input,
+			&Person{
+				ID:   i,
+				Name: "Elmer",
+				Age:  i + 10,
+				List: []string{"A", "B"},
+				Ref:  []Ref{{"id0"}},
+			})
+		input = append(
+			input,
+			User{
+				ID:   i,
+				Name: "john",
+			})
+	}
+
+	cat := &catalog
+
+	list := List{}
+	defer list.Close()
+
+	// append
+	for i := 0; i < len(input); i++ {
+		err := list.Append(input[i])
+		g.Expect(err).To(gomega.BeNil())
+	}
+	g.Expect(len(cat.content)).To(gomega.Equal(2))
+	g.Expect(list.writer.length).To(gomega.Equal(uint64(len(input))))
+	g.Expect(list.Len()).To(gomega.Equal(len(input)))
+
+	// iterate
+	itr := list.Iter()
+	defer itr.Close()
+	g.Expect(itr.Len()).To(gomega.Equal(len(input)))
+	for i := 0; i < len(input); i++ {
+		object, hasNext, err := itr.Next()
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(object).ToNot(gomega.BeNil())
+		g.Expect(hasNext).To(gomega.BeTrue())
+		g.Expect(itr.Len()).To(gomega.Equal(len(input)))
+	}
+
+	n := 0
+	itr = list.Iter()
+	g.Expect(itr.Error()).To(gomega.BeNil())
+	defer itr.Close()
+	for {
+		object, hasNext, err := itr.Next()
+		g.Expect(err).To(gomega.BeNil())
+		if hasNext {
+			n++
+		} else {
+			break
+		}
+		g.Expect(object).ToNot(gomega.BeNil())
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(hasNext).To(gomega.BeTrue())
+	}
+	g.Expect(n).To(gomega.Equal(len(input)))
+
+	n = 0
+	itr = list.Iter()
+	g.Expect(itr.Error()).To(gomega.BeNil())
+	defer itr.Close()
+	for {
+		person := &Person{}
+		hasNext, err := itr.NextWith(person)
+		g.Expect(err).To(gomega.BeNil())
+		if hasNext {
+			n++
+		} else {
+			break
+		}
+		user := &User{}
+		hasNext, err = itr.NextWith(user)
+		g.Expect(err).To(gomega.BeNil())
+		if hasNext {
+			n++
+		} else {
+			break
+		}
+		g.Expect(person).ToNot(gomega.BeNil())
+		g.Expect(user).ToNot(gomega.BeNil())
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(hasNext).To(gomega.BeTrue())
+	}
+	g.Expect(n).To(gomega.Equal(len(input)))
+
+}

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -567,8 +567,20 @@ func TestWatch(t *testing.T) {
 	// Update
 	for i := 0; i < N; i++ {
 		object := &TestObject{
-			ID:   i,
-			Name: "Fudd",
+			ID:     i,
+			Name:   "Fudd",
+			Age:    18,
+			Int8:   8,
+			Int16:  16,
+			Int32:  32,
+			Bool:   true,
+			Object: TestEncoded{Name: "json"},
+			Slice:  []string{"hello", "world"},
+			Map:    map[string]int{"A": 1, "B": 2},
+			D4:     "d-4",
+			labels: Labels{
+				"id": fmt.Sprintf("v%d", i),
+			},
 		}
 		err = DB.Update(object)
 		g.Expect(err).To(gomega.BeNil())

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -58,7 +58,7 @@ func (m *TestObject) Labels() Labels {
 
 // received event.
 type TestEvent struct {
-	action int8
+	action uint8
 	model  *TestObject
 }
 
@@ -469,6 +469,72 @@ func TestList(t *testing.T) {
 	g.Expect(count).To(gomega.Equal(int64(9)))
 }
 
+func TestIter(t *testing.T) {
+	var err error
+	g := gomega.NewGomegaWithT(t)
+	DB := New(
+		"/tmp/test.db",
+		&Label{},
+		&TestObject{})
+	err = DB.Open(true)
+	g.Expect(err).To(gomega.BeNil())
+	N := 10
+	for i := 0; i < N; i++ {
+		object := &TestObject{
+			ID:     i,
+			Name:   "Elmer",
+			Age:    18,
+			Int8:   8,
+			Int16:  16,
+			Int32:  32,
+			Bool:   true,
+			Object: TestEncoded{Name: "json"},
+			Slice:  []string{"hello", "world"},
+			Map:    map[string]int{"A": 1, "B": 2},
+			D4:     "d-4",
+			labels: Labels{
+				"id": fmt.Sprintf("v%d", i),
+			},
+		}
+		err = DB.Insert(object)
+		g.Expect(err).To(gomega.BeNil())
+	}
+	// List all; detail level=0
+	itr, err := DB.Iter(
+		&TestObject{},
+		ListOptions{})
+	g.Expect(err).To(gomega.BeNil())
+	defer itr.Close()
+	g.Expect(itr.Len()).To(gomega.Equal(10))
+	var list []TestObject
+	for {
+		object := TestObject{}
+		hasNext, err := itr.NextWith(&object)
+		if !hasNext {
+			break
+		}
+		g.Expect(err).To(gomega.BeNil())
+		list = append(list, object)
+	}
+	g.Expect(len(list)).To(gomega.Equal(10))
+	// List all; detail level=0
+	itr, err = DB.Iter(
+		&TestObject{},
+		ListOptions{})
+	defer itr.Close()
+	g.Expect(err).To(gomega.BeNil())
+	defer itr.Close()
+	for {
+		object, hasNext, err := itr.Next()
+		g.Expect(err).To(gomega.BeNil())
+		if !hasNext {
+			break
+		}
+		_, cast := object.(Model)
+		g.Expect(cast).To(gomega.BeTrue())
+	}
+}
+
 func TestWatch(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	DB := New(
@@ -550,7 +616,7 @@ func TestWatch(t *testing.T) {
 	// 5. Handler C created.  handler C should get (N) CREATE events.
 	// 6. (N) models deleted. handler A,B,C should get (N) DELETE events.
 	all := []TestEvent{}
-	for _, action := range []int8{Created, Updated, Deleted} {
+	for _, action := range []uint8{Created, Updated, Deleted} {
 		for i := 0; i < N; i++ {
 			all = append(
 				all,
@@ -587,7 +653,7 @@ func TestWatch(t *testing.T) {
 		return true
 	}()).To(gomega.BeTrue())
 	all = []TestEvent{}
-	for _, action := range []int8{Created, Deleted} {
+	for _, action := range []uint8{Created, Deleted} {
 		for i := 0; i < N; i++ {
 			all = append(
 				all,

--- a/pkg/inventory/web/handler.go
+++ b/pkg/inventory/web/handler.go
@@ -104,7 +104,7 @@ type ResourceBuilder func(model.Model) interface{}
 // Event
 type Event struct {
 	// Action.
-	Action int8
+	Action uint8
 	// Affected Resource.
 	Resource interface{}
 	// Updated resource.

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -16,16 +16,6 @@ const (
 )
 
 //
-// Logger factory.
-// As: func(string) log.Logger
-var Factory = logf.Log.WithName
-
-//
-// Name generator.
-// As: func(string) string
-var NameGenerator = names.SimpleNameGenerator.GenerateName
-
-//
 // Logger
 // Delegates functionality to the wrapped `Real` logger.
 // Provides:
@@ -41,10 +31,10 @@ type Logger struct {
 // Get a named logger.
 func WithName(name string) Logger {
 	logger := Logger{
-		Real: Factory(name),
+		Real: logf.Log.WithName(name),
 		name: name,
 	}
-
+	logger.Reset()
 	return logger
 }
 
@@ -53,8 +43,8 @@ func WithName(name string) Logger {
 // Updates the generated correlation suffix in the name.
 func (l *Logger) Reset() {
 	name := fmt.Sprintf("%s|", l.name)
-	name = NameGenerator(name)
-	l.Real = Factory(name)
+	name = names.SimpleNameGenerator.GenerateName(name)
+	l.Real = logf.Log.WithName(name)
 }
 
 //

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -15,9 +15,7 @@ type entry struct {
 }
 
 type fake struct {
-	entry  []entry
-	values []interface{}
-	name   string
+	entry []entry
 }
 
 func (l *fake) Info(message string, kvpair ...interface{}) {
@@ -39,23 +37,21 @@ func (l *fake) Error(err error, message string, kvpair ...interface{}) {
 		})
 }
 
-func (l *fake) Enabled() bool {
+func (l fake) Enabled() bool {
 	return true
 }
 
-func (l *fake) V(level int) logr.InfoLogger {
+func (l fake) V(level int) logr.InfoLogger {
 	return nil
 }
 
-func (l *fake) WithName(name string) logr.Logger {
-	l.name = name
-	return l
+func (l fake) WithName(name string) logr.Logger {
+	return nil
 }
 
 //
 // Get logger with values.
-func (l *fake) WithValues(kvpair ...interface{}) logr.Logger {
-	l.values = kvpair
+func (l fake) WithValues(kvpair ...interface{}) logr.Logger {
 	return nil
 }
 
@@ -67,25 +63,11 @@ func TestLogger(t *testing.T) {
 	log.Info("hello")
 	log.Error(errors.New("A"), "thing failed")
 	log.Trace(errors.New("B"))
-	g.Expect(log.name).To(gomega.Equal("Test"))
-	log.Reset()
 	//
-	// Fake.
-	NameGenerator = func(name string) string {
-		return name + "1234"
-	}
-	Factory = func(name string) logr.Logger {
-		return &fake{
-			entry: []entry{},
-			name:  name,
-		}
-	}
-	log = WithName("Test")
-	f := log.Real.(*fake)
-	g.Expect(f.name).To(gomega.Equal("Test"))
+	// Faked
 	log.Reset()
-	f = log.Real.(*fake)
-	g.Expect(f.name).To(gomega.Equal("Test|1234"))
+	f := &fake{entry: []entry{}}
+	log.Real = f
 	// Info
 	log.Info("hello")
 	g.Expect(len(f.entry)).To(gomega.Equal(1))


### PR DESCRIPTION
Add `filebacked` package which provides file-backed collections.

The goal is to: Reduce memory footprint for flows that require holding (potentially) large collections of objects.

The design is to: briefly cache the collections on disk.

Known use cases in the `inventory` package:
- The journal needs to _stage_ change events during transactions.
- The journal needs to queue (potentially) large number of `Event` to watch handlers WITHOUT blocking DB updates or holding the DB lock.
- The web package needs to be able to `List()` (potentially) large numbers of objects to be streamed back WITHOUT holding the DB lock.

This is most necessary for the journal/watch because it is a producer/consumer workflow with no guarantee the consumer can keep up with the producer.

---

Unrelated:  Noticed the Event.Action was a signed 8 bit integer and really should be a n _unsigned_ integer.