### PR TITLE
Logger support plan named; Support logger and name generator factory.

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -16,6 +16,16 @@ const (
 )
 
 //
+// Logger factory.
+// As: func(string) log.Logger
+var Factory = logf.Log.WithName
+
+//
+// Name generator.
+// As: func(string) string
+var NameGenerator = names.SimpleNameGenerator.GenerateName
+
+//
 // Logger
 // Delegates functionality to the wrapped `Real` logger.
 // Provides:
@@ -31,10 +41,10 @@ type Logger struct {
 // Get a named logger.
 func WithName(name string) Logger {
 	logger := Logger{
-		Real: logf.Log.WithName(name),
+		Real: Factory(name),
 		name: name,
 	}
-	logger.Reset()
+
 	return logger
 }
 
@@ -43,8 +53,8 @@ func WithName(name string) Logger {
 // Updates the generated correlation suffix in the name.
 func (l *Logger) Reset() {
 	name := fmt.Sprintf("%s|", l.name)
-	name = names.SimpleNameGenerator.GenerateName(name)
-	l.Real = logf.Log.WithName(name)
+	name = NameGenerator(name)
+	l.Real = Factory(name)
 }
 
 //


### PR DESCRIPTION
Re-apply changes from https://github.com/konveyor/controller/pull/61 accidentally reverted by https://github.com/konveyor/controller/pull/60.