### PR TITLE
Better logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,46 @@
 Common controller lib.  Provides components shared by application controllers.
 
 Requires: Go 1.13+ and Go Modules
+
+---
+**Logging**
+
+Logging can be configured using environment variables:
+- LOG_DEVELOPMENT: Development mode with human readable logs and (default) verbosity=4.
+- LOG_LEVEL: Set the verbosity.
+
+Verbosity:
+- Info(3) used for `Info` logging.
+- Info(4) used for `Debug` logging.
+- Info(5) used for `Debug+` high rate events.
+
+Package:
+- filebacked:
+  - Info(3): none.
+  - Info(4): file lifecycle.
+  - Info(5): file read,write.
+- inventory:
+  - container:
+    - Info(3): reconciler lifecycle.
+    - Error(4): channel send failed.
+  - model:
+    - Info(3):
+      - database: lifecycle.
+      - journal: journal and watch lifecycle.
+    - Info(4):
+      - client: (db) transaction lifecycle;model CRUD.
+      - journal: event staging.
+      - watch: lifecycle.
+    - Info(5):
+      - watch: event sent,received.
+  - web:
+    - Info(3):
+      - watch: lifecycle.
+    - Info(4):
+      - watch: event sent,received. 
+  - ref:
+    - Info(3): _reference_ mapping added,deleted.
+    - Info(4): _reference_ lookup and reconcile events queued.
+
+---
+

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.3.0
-	github.com/go-logr/zapr v0.3.0 // indirect
+	github.com/go-logr/zapr v0.3.0
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
@@ -27,6 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
+	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
 	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 // indirect

--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -105,11 +105,24 @@
 //
 package model
 
+import "github.com/konveyor/controller/pkg/logging"
+
 //
 // New database.
 func New(path string, models ...interface{}) DB {
-	return &Client{
+	client := &Client{
 		path:   path,
 		models: models,
 	}
+	client.log = logging.WithName("model|db").WithValues(
+		"path",
+		path)
+	client.journal.log = logging.WithName("db|journal").WithValues(
+		"db",
+		path)
+	client.labeler.log = logging.WithName("db|labeler").WithValues(
+		"db",
+		path)
+
+	return client
 }

--- a/pkg/inventory/model/model.go
+++ b/pkg/inventory/model/model.go
@@ -2,9 +2,14 @@ package model
 
 import (
 	"database/sql"
+	"github.com/konveyor/controller/pkg/logging"
 	_ "github.com/mattn/go-sqlite3"
 	"reflect"
 )
+
+//
+// Package logger.
+var log = logging.WithName("model")
 
 //
 // Errors.

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -74,7 +74,7 @@ type TestHandler struct {
 	done    bool
 }
 
-func (w *TestHandler) Started() {
+func (w *TestHandler) Started(uint64) {
 	w.started = true
 }
 
@@ -119,7 +119,7 @@ type MutatingHandler struct {
 	updated []int
 }
 
-func (w *MutatingHandler) Started() {
+func (w *MutatingHandler) Started(uint64) {
 	w.started = true
 }
 

--- a/pkg/inventory/web/web.go
+++ b/pkg/inventory/web/web.go
@@ -5,9 +5,14 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/controller/pkg/inventory/container"
+	"github.com/konveyor/controller/pkg/logging"
 	"regexp"
 	"time"
 )
+
+//
+// Package logger.
+var log = logging.WithName("web")
 
 //
 // Web server
@@ -53,6 +58,11 @@ func (w *WebServer) Start() {
 	} else {
 		go router.Run(w.address())
 	}
+
+	log.V(3).Info(
+		"web: engine started.",
+		"address",
+		w.address())
 }
 
 //

--- a/pkg/logging/factory.go
+++ b/pkg/logging/factory.go
@@ -1,0 +1,79 @@
+package logging
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"os"
+	"time"
+)
+
+//
+// Builder.
+type Builder interface {
+	New() logr.Logger
+	V(int, logr.Logger) logr.Logger
+}
+
+//
+// Zap builder factory.
+type ZapBuilder struct {
+}
+
+//
+// Build new logger.
+func (b *ZapBuilder) New() (l logr.Logger) {
+	var encoder zapcore.Encoder
+	var options []zap.Option
+	sinker := zapcore.AddSync(os.Stderr)
+	if Settings.Development {
+		cfg := zap.NewDevelopmentEncoderConfig()
+		encoder = zapcore.NewConsoleEncoder(cfg)
+		options = append(
+			options,
+			zap.Development(),
+			zap.AddStacktrace(zap.ErrorLevel))
+	} else {
+		cfg := zap.NewProductionEncoderConfig()
+		encoder = zapcore.NewJSONEncoder(cfg)
+		options = append(
+			options,
+			zap.AddStacktrace(zap.WarnLevel),
+			zap.WrapCore(
+				func(core zapcore.Core) zapcore.Core {
+					return zapcore.NewSampler(
+						core,
+						time.Second,
+						100,
+						100)
+				}))
+	}
+	level := zap.NewAtomicLevelAt(zap.DebugLevel)
+	options = append(
+		options,
+		zap.AddCallerSkip(1),
+		zap.ErrorOutput(sinker))
+	log := zap.New(
+		zapcore.NewCore(
+			encoder,
+			sinker,
+			level))
+	log = log.WithOptions(options...)
+	l = zapr.NewLogger(log)
+
+	return
+}
+
+//
+// Debug logger.
+func (b *ZapBuilder) V(level int, in logr.Logger) (l logr.Logger) {
+	l = in
+	if Settings.atDebug(level) {
+		l = l.V(int(zap.DebugLevel))
+	} else {
+		l = in
+	}
+
+	return
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,12 +1,10 @@
 package logging
 
 import (
-	"fmt"
 	"github.com/go-logr/logr"
 	liberr "github.com/konveyor/controller/pkg/error"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apiserver/pkg/storage/names"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"os"
+	"strconv"
 )
 
 const (
@@ -14,73 +12,75 @@ const (
 	Error = "error"
 	None  = ""
 )
+const (
+	EnvDevelopment = "LOG_DEVELOPMENT"
+	EnvLevel       = "LOG_LEVEL"
+)
+
+//
+// Settings.
+var Settings _Settings
+
+func init() {
+	Settings.Load()
+}
 
 //
 // Logger factory.
-// As: func(string) log.Logger
-var Factory = logf.Log.WithName
+var Factory Builder
 
-//
-// Name generator.
-// As: func(string) string
-var NameGenerator = names.SimpleNameGenerator.GenerateName
+func init() {
+	Factory = &ZapBuilder{}
+}
 
 //
 // Logger
 // Delegates functionality to the wrapped `Real` logger.
 // Provides:
 //   - Provides a `Trace()` method for convenience and brevity.
-//   - Prevent spamming the log with `Conflict` errors.
 //   - Handles wrapped errors.
 type Logger struct {
+	// Real (wrapped) logger.
 	Real logr.Logger
+	// Name.
 	name string
+	// Level.
+	level int
 }
 
 //
 // Get a named logger.
-func WithName(name string) Logger {
-	logger := Logger{
-		Real: Factory(name),
+func WithName(name string, kvpair ...interface{}) *Logger {
+	l := &Logger{
+		Real: Factory.New(),
 		name: name,
 	}
-
-	return logger
-}
-
-//
-// Reset the logger.
-// Updates the generated correlation suffix in the name.
-func (l *Logger) Reset() {
-	name := fmt.Sprintf("%s|", l.name)
-	name = NameGenerator(name)
-	l.Real = Factory(name)
-}
-
-//
-// Set values.
-func (l *Logger) SetValues(kvpair ...interface{}) {
 	l.Real = l.Real.WithValues(kvpair...)
+	l.Real = l.Real.WithName(name)
+
+	return l
 }
 
 //
 // Logs at info.
-func (l Logger) Info(message string, kvpair ...interface{}) {
-	l.Real.Info(message, kvpair...)
+func (l *Logger) Info(message string, kvpair ...interface{}) {
+	if Settings.allowed(l.level) {
+		l.Real.Info(message, kvpair...)
+	}
 }
 
 //
 // Logs an error.
-func (l Logger) Error(err error, message string, kvpair ...interface{}) {
+func (l *Logger) Error(err error, message string, kvpair ...interface{}) {
 	if err == nil {
+		return
+	}
+	if !Settings.allowed(l.level) {
 		return
 	}
 	le, wrapped := err.(*liberr.Error)
 	if wrapped {
 		err = le.Unwrap()
-		if k8serr.IsConflict(err) {
-			return
-		}
 		if context := le.Context(); context != nil {
 			context = append(
 				context,
@@ -102,7 +102,7 @@ func (l Logger) Error(err error, message string, kvpair ...interface{}) {
 	}); wrapped {
 		err = wErr.Unwrap()
 	}
-	if err == nil || k8serr.IsConflict(err) {
+	if err == nil {
 		return
 	}
 
@@ -111,36 +111,86 @@ func (l Logger) Error(err error, message string, kvpair ...interface{}) {
 
 //
 // Logs an error without a description.
-func (l Logger) Trace(err error, kvpair ...interface{}) {
+func (l *Logger) Trace(err error, kvpair ...interface{}) {
 	l.Error(err, None, kvpair...)
 }
 
 //
 // Get whether logger is enabled.
-func (l Logger) Enabled() bool {
+func (l *Logger) Enabled() bool {
 	return l.Real.Enabled()
 }
 
 //
 // Get logger with verbosity level.
-func (l Logger) V(level int) logr.InfoLogger {
-	return l.Real.V(level)
+func (l *Logger) V(level int) logr.InfoLogger {
+	return &Logger{
+		Real:  Factory.V(level, l.Real),
+		name:  l.name,
+		level: level,
+	}
 }
 
 //
 // Get logger with name.
-func (l Logger) WithName(name string) logr.Logger {
-	return Logger{
-		Real: l.Real.WithName(name),
-		name: l.name,
+func (l *Logger) WithName(name string) logr.Logger {
+	return &Logger{
+		Real:  l.Real.WithName(name),
+		name:  name,
+		level: l.level,
 	}
 }
 
 //
 // Get logger with values.
-func (l Logger) WithValues(kvpair ...interface{}) logr.Logger {
-	return Logger{
-		Real: l.Real.WithValues(kvpair...),
-		name: l.name,
+func (l *Logger) WithValues(kvpair ...interface{}) logr.Logger {
+	return &Logger{
+		Real:  l.Real.WithValues(kvpair...),
+		name:  l.name,
+		level: l.level,
 	}
+}
+
+//
+// Package settings.
+type _Settings struct {
+	// Debug threshold.
+	// Level determines when the real
+	// debug logger is used.
+	DebugThreshold int
+	// Development configuration.
+	Development bool
+	// Info level threshold.
+	// Higher level increases verbosity.
+	Level int
+}
+
+//
+// Determine development logger.
+func (r *_Settings) Load() {
+	r.DebugThreshold = 4
+	if s, found := os.LookupEnv(EnvDevelopment); found {
+		bv, err := strconv.ParseBool(s)
+		if err == nil {
+			r.Development = bv
+		}
+	}
+	if s, found := os.LookupEnv(EnvLevel); found {
+		n, err := strconv.ParseInt(s, 10, 8)
+		if err == nil {
+			r.Level = int(n)
+		}
+	}
+}
+
+//
+// The level is at (or above) the level setting.
+func (r *_Settings) allowed(level int) bool {
+	return r.Level >= level
+}
+
+//
+// The level is at or above the debug threshold.
+func (r *_Settings) atDebug(level int) bool {
+	return level >= r.DebugThreshold
 }

--- a/pkg/ref/mapping.go
+++ b/pkg/ref/mapping.go
@@ -30,6 +30,13 @@ func (r *RefMap) Add(owner Owner, target Target) {
 	}
 
 	r.Content[target][owner] = true
+
+	log.V(3).Info(
+		"map: added.",
+		"owner",
+		owner,
+		"target",
+		target)
 }
 
 //
@@ -40,6 +47,10 @@ func (r *RefMap) Delete(owner Owner, target Target) {
 	owners, found := r.Content[target]
 	if found {
 		delete(owners, owner)
+		log.V(3).Info(
+			"map: owner deleted.",
+			"owner",
+			owner)
 	}
 	r.Prune()
 }
@@ -51,6 +62,10 @@ func (r *RefMap) DeleteOwner(owner Owner) {
 	defer r.mutex.Unlock()
 	for _, owners := range r.Content {
 		delete(owners, owner)
+		log.V(3).Info(
+			"map: owner deleted.",
+			"owner",
+			owner)
 	}
 	r.Prune()
 }
@@ -79,6 +94,12 @@ func (r *RefMap) Find(target Target) []Owner {
 			list = append(list, owner)
 		}
 	}
+	log.V(4).Info(
+		"map: found owner for target.",
+		"target",
+		target,
+		"owner",
+		list)
 
 	return list
 }

--- a/pkg/ref/predicate.go
+++ b/pkg/ref/predicate.go
@@ -32,8 +32,13 @@ type EventMapper struct {
 //
 // Create event.
 func (r *EventMapper) Create(event event.CreateEvent) {
+	kind := ToKind(event.Object)
+	log.V(4).Info(
+		"mapper: created event.",
+		"kind",
+		kind)
 	refOwner := Owner{
-		Kind:      ToKind(event.Object),
+		Kind:      kind,
 		Namespace: event.Meta.GetNamespace(),
 		Name:      event.Meta.GetName(),
 	}
@@ -45,13 +50,18 @@ func (r *EventMapper) Create(event event.CreateEvent) {
 //
 // Update event.
 func (r *EventMapper) Update(event event.UpdateEvent) {
+	kind := ToKind(event.ObjectNew)
+	log.V(4).Info(
+		"mapper: updated event.",
+		"kind",
+		kind)
 	r.Map.DeleteOwner(Owner{
-		Kind:      ToKind(event.ObjectOld),
+		Kind:      kind,
 		Namespace: event.MetaOld.GetNamespace(),
 		Name:      event.MetaOld.GetName(),
 	})
 	refOwner := Owner{
-		Kind:      ToKind(event.ObjectNew),
+		Kind:      kind,
 		Namespace: event.MetaNew.GetNamespace(),
 		Name:      event.MetaNew.GetName(),
 	}
@@ -63,8 +73,13 @@ func (r *EventMapper) Update(event event.UpdateEvent) {
 //
 // Delete Mapper.
 func (r *EventMapper) Delete(event event.DeleteEvent) {
+	kind := ToKind(event.Object)
+	log.V(4).Info(
+		"mapper: deleted event.",
+		"kind",
+		kind)
 	r.Map.DeleteOwner(Owner{
-		Kind:      ToKind(event.Object),
+		Kind:      kind,
 		Namespace: event.Meta.GetNamespace(),
 		Name:      event.Meta.GetName(),
 	})

--- a/pkg/ref/ref.go
+++ b/pkg/ref/ref.go
@@ -1,6 +1,7 @@
 package ref
 
 import (
+	"github.com/konveyor/controller/pkg/logging"
 	"k8s.io/api/core/v1"
 	"reflect"
 )
@@ -8,6 +9,8 @@ import (
 // Global
 var Map *RefMap
 var Mapper *EventMapper
+
+var log = logging.WithName("ref")
 
 //
 // Build globals.

--- a/pkg/ref/ref_test.go
+++ b/pkg/ref/ref_test.go
@@ -307,6 +307,7 @@ func TestHandler(t *testing.T) {
 		})
 
 	list := GetRequests(
+		ToKind(&_Thing{}),
 		handler.MapObject{
 			Meta:   target,
 			Object: target,


### PR DESCRIPTION
Add logger to many objects.
Strategic add of logging statements.
Add context to wrapped/returned `error`.

The log level approach:
- Level=**0-2** not used by the lib.  reserved for applications.
- Level=**3** for: basic `info` logging for high level things created/deleted opened/closed.
- Level=**4** for: basic `debug`.  has a lot of detail but relatively low numbers
- Level=**5** for: low level `debug`.  high volume changes like watch events and _filebacked_ read/write.

Added an `id` to both `model.Watch` and both `model.Event` and `web.Event` for better tracability.

change some function calls where the return is deliberately ignored (for clarity) to:
```
_ = fn()
```

Fixed a bug in the `ref` package for _references watches_.  The handler needed to filter for by reference _owner_ type. 
Fixed a bug .fb files leaked when an iterator is closed but never read.  Also added a finalizer so GC iterators will be closed and hard-link deleted. Use case for this would be: iter is written to a channel but the watch is terminated before the channel is drained.

Few changes to the logging.Logger.  Mainly:
- changed to pointer receiver.
-  removed Logger.Reset().  More appropriate for the controller to just use .WithName() to reset the name as needed.
- Added a package `Factory` that creates a `zap` logger by default.  Has support for environment variables for both _developement_ mode and logging _level_.
- Add true support for verbosity levels.  0-4 = Info, 4+ = debug.