### PR TITLE
Fix leaked iterator file.

### DIFF
--- a/pkg/filebacked/file.go
+++ b/pkg/filebacked/file.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	pathlib "path"
+	"runtime"
 )
 
 //
@@ -77,6 +78,11 @@ func (w *Writer) Reader() (reader *Reader) {
 		error: liberr.Wrap(err),
 		path:  path,
 	}
+	runtime.SetFinalizer(
+		reader,
+		func(r *Reader) {
+			r.Close()
+		})
 
 	return
 }
@@ -357,9 +363,10 @@ func (r *Reader) open() (err error) {
 func (r *Reader) Close() {
 	if r.file != nil {
 		_ = r.file.Close()
-		_ = os.Remove(r.path)
 		r.file = nil
 	}
+	// Unlink.
+	_ = os.Remove(r.path)
 }
 
 //


### PR DESCRIPTION
Fix leaked iterator file.  The file needs to be unlinked (removed) even if never read.
Also, added finalizer to close() the iterator if the `itr` is garbage collected.  For example if written to a _channel_ and the channel is closed before it is drained.