### PR TITLE
Fix watch leak.

### DIFF
--- a/pkg/filebacked/list.go
+++ b/pkg/filebacked/list.go
@@ -3,8 +3,7 @@ Provides file-backed list.
 
 //
 // New list.
-list := fb.List{}
-defer list.Close()
+list := fb.NewList()
 
 //
 // Append an object.
@@ -13,7 +12,6 @@ err := list.Append(object)
 //
 // Iterate the list.
 itr := list.Iter()
-defer itr.Close()
 for {
     object, hasNext, err := itr.Next()
     if err != nil || !hasNext {
@@ -24,7 +22,6 @@ for {
 //
 // Iterate the list.
 itr := list.Iter()
-defer itr.Close()
 for {
     person := Person{}
     hasNext, err := itr.NextWith(&person))
@@ -34,6 +31,20 @@ for {
 }
 */
 package filebacked
+
+import "runtime"
+
+//
+// List factory.
+func NewList() (list *List) {
+	list = &List{}
+	runtime.SetFinalizer(
+		list,
+		func(l *List) {
+			l.Close()
+		})
+	return
+}
 
 //
 // File-backed list.

--- a/pkg/filebacked/list_test.go
+++ b/pkg/filebacked/list_test.go
@@ -46,8 +46,7 @@ func TestList(t *testing.T) {
 
 	cat := &catalog
 
-	list := List{}
-	defer list.Close()
+	list := NewList()
 
 	// append
 	for i := 0; i < len(input); i++ {
@@ -60,7 +59,6 @@ func TestList(t *testing.T) {
 
 	// iterate
 	itr := list.Iter()
-	defer itr.Close()
 	g.Expect(itr.Len()).To(gomega.Equal(len(input)))
 	for i := 0; i < len(input); i++ {
 		object, hasNext, err := itr.Next()
@@ -73,7 +71,6 @@ func TestList(t *testing.T) {
 	n := 0
 	itr = list.Iter()
 	g.Expect(itr.Error()).To(gomega.BeNil())
-	defer itr.Close()
 	for {
 		object, hasNext, err := itr.Next()
 		g.Expect(err).To(gomega.BeNil())
@@ -91,7 +88,6 @@ func TestList(t *testing.T) {
 	n = 0
 	itr = list.Iter()
 	g.Expect(itr.Error()).To(gomega.BeNil())
-	defer itr.Close()
 	for {
 		person := &Person{}
 		hasNext, err := itr.NextWith(person)

--- a/pkg/inventory/model/journal.go
+++ b/pkg/inventory/model/journal.go
@@ -147,7 +147,6 @@ func (w *Watch) notify(itr fb.Iterator) {
 	select {
 	case w.queue <- itr:
 	default:
-		itr.Close()
 		description := "full queue, event discarded"
 		w.Handler.Error(liberr.New(description))
 		w.log.V(3).Info(description)
@@ -202,7 +201,6 @@ func (w *Watch) Start() {
 				}
 			}
 			count++
-			itr.Close()
 			if count == 1 {
 				w.log.V(3).Info("has parity.")
 				w.Handler.Parity()

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -504,7 +504,6 @@ func TestIter(t *testing.T) {
 		&TestObject{},
 		ListOptions{})
 	g.Expect(err).To(gomega.BeNil())
-	defer itr.Close()
 	g.Expect(itr.Len()).To(gomega.Equal(10))
 	var list []TestObject
 	for {
@@ -521,9 +520,7 @@ func TestIter(t *testing.T) {
 	itr, err = DB.Iter(
 		&TestObject{},
 		ListOptions{})
-	defer itr.Close()
 	g.Expect(err).To(gomega.BeNil())
-	defer itr.Close()
 	for {
 		object, hasNext, err := itr.Next()
 		g.Expect(err).To(gomega.BeNil())

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -461,8 +461,7 @@ func (t Table) Iter(model interface{}, options ListOptions) (itr fb.Iterator, er
 	defer func() {
 		_ = cursor.Close()
 	}()
-	list := fb.List{}
-	defer list.Close()
+	list := fb.NewList()
 	for cursor.Next() {
 		mt := reflect.TypeOf(model)
 		mPtr := reflect.New(mt.Elem())

--- a/pkg/inventory/web/handler.go
+++ b/pkg/inventory/web/handler.go
@@ -163,9 +163,14 @@ type WatchWriter struct {
 
 //
 // End.
+// Close the socket.
+// End the watch.
+// Reset the watch (pointer) to release both
+// objects for garbage collection.
 func (r *WatchWriter) end() {
 	_ = r.webSocket.Close()
 	r.watch.End()
+	r.watch = &model.Watch{}
 	r.log.V(3).Info("watch ended.")
 }
 
@@ -312,11 +317,13 @@ func (r *Watched) Watch(
 		builder:   rb,
 		log:       wlog,
 	}
-	writer.watch, err = db.Watch(m, writer)
+	watch, err := db.Watch(m, writer)
 	if err != nil {
 		_ = socket.Close()
 		return
 	}
+
+	writer.watch = watch
 
 	log.V(3).Info(
 		"handler: watch created.",


### PR DESCRIPTION
Fix watch leaked when:
- There is an error after the watch is created but before it is successfully returned.
- A _web_ layer watch terminates.  The watch <=> handler (circular) relationship will prevent GC.

Also, adding `NewList()` which creates a list with a  _finalizer_  set.  The `Iterator` already` has a finalizer.  This is more consistent, intuitive and safer.