### PR TITLE
Add index() field tag.

### DIFF
--- a/pkg/inventory/model/client.go
+++ b/pkg/inventory/model/client.go
@@ -22,6 +22,8 @@ type DB interface {
 	Open(bool) error
 	// Close.
 	Close(bool) error
+	// Execute SQL.
+	Execute(sql string) (sql.Result, error)
 	// Get the specified model.
 	Get(Model) error
 	// List models based on the type of slice.
@@ -138,6 +140,14 @@ func (r *Client) Close(purge bool) error {
 	r.log.V(3).Info("DB closed.")
 
 	return nil
+}
+
+//
+// Execute SQL.
+func (r *Client) Execute(sql string) (sql.Result, error) {
+	r.dbMutex.Lock()
+	defer r.dbMutex.Unlock()
+	return r.db.Exec(sql)
 }
 
 //

--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -11,6 +11,8 @@
 //       Foreign key `T` = model type, `F` = model field.
 //   `sql:"unique(G)"`
 //       Unique index. `G` = unique-together fields.
+//   `sql:"index(G)"`
+//       Non-unique index. `G` = unique-together fields.
 //   `sql:"const"`
 //       The field is immutable and not included on update.
 //   `sql:"virtual"`

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -24,8 +24,8 @@ type TestObject struct {
 	RowID  int64          `sql:"virtual"`
 	PK     string         `sql:"pk,generated(id)"`
 	ID     int            `sql:"key"`
-	Name   string         `sql:""`
-	Age    int            `sql:""`
+	Name   string         `sql:"index(a)"`
+	Age    int            `sql:"index(a)"`
 	Int8   int8           `sql:""`
 	Int16  int16          `sql:""`
 	Int32  int32          `sql:""`

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -311,7 +311,7 @@ func (t Table) IndexDDL(model interface{}, fields []*Field) (list []string, err 
 			bfr,
 			TmplData{
 				Table:  t.Name(model),
-				Index:  t.Name(model)+group,
+				Index:  t.Name(model) + group,
 				Fields: t.RealFields(idxFields),
 			})
 		if err != nil {

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS {{.Table}} (
 `
 
 var IndexDDL = `
-CREATE INDEX IF NOT EXISTS {{.Table}}Index
+CREATE INDEX IF NOT EXISTS {{.Index}}Index
 ON {{.Table}}
 (
 {{ range $i,$f := .Fields -}}
@@ -195,21 +195,49 @@ func (t Table) Validate(fields []*Field) error {
 
 //
 // Get table and index create DDL.
-func (t Table) DDL(model interface{}) ([]string, error) {
-	list := []string{}
-	tpl := template.New("")
+func (t Table) DDL(model interface{}) (list []string, err error) {
+	list = []string{}
 	fields, err := t.Fields(model)
 	if err != nil {
-		return nil, err
+		return
 	}
 	err = t.Validate(fields)
 	if err != nil {
-		return nil, err
+		return
 	}
-	// Table
+	ddl, err := t.TableDDL(model, fields)
+	if err != nil {
+		return
+	}
+	for _, stmt := range ddl {
+		list = append(list, stmt)
+	}
+	ddl, err = t.KeyIndexDDL(model, fields)
+	if err != nil {
+		return
+	}
+	for _, stmt := range ddl {
+		list = append(list, stmt)
+	}
+	ddl, err = t.IndexDDL(model, fields)
+	if err != nil {
+		return
+	}
+	for _, stmt := range ddl {
+		list = append(list, stmt)
+	}
+
+	return
+}
+
+//
+// Build table DDL.
+func (t Table) TableDDL(model interface{}, fields []*Field) (list []string, err error) {
+	tpl := template.New("")
 	tpl, err = tpl.Parse(TableDDL)
 	if err != nil {
-		return nil, liberr.Wrap(err)
+		err = liberr.Wrap(err)
+		return
 	}
 	constraints := t.Constraints(fields)
 	bfr := &bytes.Buffer{}
@@ -221,30 +249,79 @@ func (t Table) DDL(model interface{}) ([]string, error) {
 			Constraints: constraints,
 		})
 	if err != nil {
-		return nil, liberr.Wrap(err)
+		err = liberr.Wrap(err)
+		return
 	}
 	list = append(list, bfr.String())
-	// Index.
-	fields = t.KeyFields(fields)
-	if len(fields) > 0 {
+	return
+}
+
+//
+// Build natural key index DDL.
+func (t Table) KeyIndexDDL(model interface{}, fields []*Field) (list []string, err error) {
+	tpl := template.New("")
+	keyFields := t.KeyFields(fields)
+	if len(keyFields) > 0 {
 		tpl, err = tpl.Parse(IndexDDL)
 		if err != nil {
-			return nil, liberr.Wrap(err)
+			err = liberr.Wrap(err)
+			return
 		}
-		bfr = &bytes.Buffer{}
+		bfr := &bytes.Buffer{}
 		err = tpl.Execute(
 			bfr,
 			TmplData{
 				Table:  t.Name(model),
-				Fields: t.RealFields(fields),
+				Index:  t.Name(model),
+				Fields: t.RealFields(keyFields),
 			})
 		if err != nil {
-			return nil, liberr.Wrap(err)
+			err = liberr.Wrap(err)
+			return
 		}
 		list = append(list, bfr.String())
 	}
 
-	return list, nil
+	return
+}
+
+//
+// Build non-unique index DDL.
+func (t Table) IndexDDL(model interface{}, fields []*Field) (list []string, err error) {
+	tpl := template.New("")
+	index := map[string][]*Field{}
+	for _, field := range fields {
+		for _, group := range field.Index() {
+			list, found := index[group]
+			if found {
+				index[group] = append(list, field)
+			} else {
+				index[group] = []*Field{field}
+			}
+		}
+	}
+	for group, idxFields := range index {
+		tpl, err = tpl.Parse(IndexDDL)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		bfr := &bytes.Buffer{}
+		err = tpl.Execute(
+			bfr,
+			TmplData{
+				Table:  t.Name(model),
+				Index:  t.Name(model)+group,
+				Fields: t.RealFields(idxFields),
+			})
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		list = append(list, bfr.String())
+	}
+
+	return
 }
 
 //
@@ -895,6 +972,10 @@ func (t Table) scan(row Row, fields []*Field) error {
 var UniqueRegex = regexp.MustCompile(`(unique)(\()(.+)(\))`)
 
 //
+// Regex used for `index(group)` tags.
+var IndexRegex = regexp.MustCompile(`(index)(\()(.+)(\))`)
+
+//
 // Regex used for `fk:<table>(field)` tags.
 var FkRegex = regexp.MustCompile(`(fk):(.+)(\()(.+)(\))`)
 
@@ -909,8 +990,14 @@ var FkRegex = regexp.MustCompile(`(fk):(.+)(\()(.+)(\))`)
 //       Foreign key `T` = model type, `F` = model field.
 //   `sql:"unique(G)"`
 //       Unique index. `G` = unique-together fields.
+//   `sql:"index(G)"`
+//       Non-unique index. `G` = unique-together fields.
 //   `sql:"const"`
 //       The field is immutable and not included on update.
+//   `sql:"virtual"`
+//       The field is read-only and managed internally by the DB.
+//   `sql:"dn"`
+//       The field detail level.  n = level number (0-9).
 //
 type Field struct {
 	// reflect.Value of the field.
@@ -1146,6 +1233,21 @@ func (f *Field) Unique() []string {
 }
 
 //
+// Get whether the field has non-unique index.
+func (f *Field) Index() []string {
+	list := []string{}
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		m := IndexRegex.FindStringSubmatch(opt)
+		if m != nil && len(m) == 5 {
+			list = append(list, m[3])
+		}
+	}
+
+	return list
+}
+
+//
 // Get whether the field is a foreign key.
 func (f *Field) Fk() *FK {
 	for _, opt := range strings.Split(f.Tag, ",") {
@@ -1332,6 +1434,8 @@ func (f *FK) DDL(field *Field) string {
 type TmplData struct {
 	// Table name.
 	Table string
+	// Index name.
+	Index string
 	// Fields.
 	Fields []*Field
 	// Constraint DDL.


### PR DESCRIPTION
Add index() field tag.  This will create a non-unique index for fields in the _group_.
Example:
```
type Person struct {
    Name string `sql:"index(a)"`
}
```
---

Add DB.Execute(sql string) to support running arbitrary SQL needed to support editing table data outside of the _Model_.