### PR TITLE
General hardening and leak fixes for model and web packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@ GOOS ?= `go env GOOS`
 GOBIN ?= ${GOPATH}/bin
 
 # Run tests
-test: generate fmt vet
+test: build
 	go test ./pkg/... -coverprofile cover.out
+	export LOG_DEVELOPMENT=1;\
+		export LOG_LEVEL=3;\
+		bin/inventory
+
+# Build.
+build: generate fmt vet
+	mkdir -p bin
+	go build -o bin/inventory github.com/konveyor/controller/pkg/cmd/inventory
 
 # Run go fmt against code
 fmt:

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,0 +1,3 @@
+//
+// Provides integration testing.
+package cmd

--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -107,7 +107,9 @@
 //
 package model
 
-import "github.com/konveyor/controller/pkg/logging"
+import (
+	"github.com/konveyor/controller/pkg/logging"
+)
 
 //
 // New database.

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -741,6 +741,7 @@ func TestMutatingWatch(t *testing.T) {
 	err := DB.Open(true)
 
 	g.Expect(err).To(gomega.BeNil())
+
 	// Handler A
 	handlerA := &MutatingHandler{
 		name: "A",


### PR DESCRIPTION
General hardening.

Fix leaked `Watch` terminated when DB closed.
Fixed leaked `WatchWriter` when peer closes connection or connection broken.
Fixed _database locked_ error when transaction is committed when another goroutine is iterating a DB cursor (Rows).
Added finalizers for additional leak protection.
Updated logger factory to not add the `Sampler` for non-development logger.  This used a ton of memory and I don't think it's worth the cost.
Added _integration_ test for the web/model stack.