### PR TITLE
Adjust model detail levels.

### DIFF
--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -33,6 +33,9 @@ type TestObject struct {
 	Object TestEncoded    `sql:""`
 	Slice  []string       `sql:""`
 	Map    map[string]int `sql:""`
+	D1     string         `sql:"d1"`
+	D2     string         `sql:"d2"`
+	D3     string         `sql:"d3"`
 	D4     string         `sql:"d4"`
 	labels Labels
 }
@@ -296,6 +299,9 @@ func TestList(t *testing.T) {
 			Object: TestEncoded{Name: "json"},
 			Slice:  []string{"hello", "world"},
 			Map:    map[string]int{"A": 1, "B": 2},
+			D1:     "d-1",
+			D2:     "d-2",
+			D3:     "d-3",
 			D4:     "d-4",
 			labels: Labels{
 				"id": fmt.Sprintf("v%d", i),
@@ -310,21 +316,33 @@ func TestList(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(10))
 	g.Expect(list[0].Name).To(gomega.Equal(""))
+	g.Expect(list[0].Slice).To(gomega.BeNil())
+	g.Expect(list[0].D1).To(gomega.Equal(""))
+	g.Expect(list[0].D2).To(gomega.Equal(""))
+	g.Expect(list[0].D3).To(gomega.Equal(""))
 	g.Expect(list[0].D4).To(gomega.Equal(""))
-	// List detail level=1 (all)
+	// List detail level=1
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: 1})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(10))
 	g.Expect(list[0].Name).To(gomega.Equal("Elmer"))
-	g.Expect(list[0].D4).To(gomega.Equal("d-4"))
+	g.Expect(len(list[0].Slice)).To(gomega.Equal(2))
+	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
+	g.Expect(list[0].D2).To(gomega.Equal(""))
+	g.Expect(list[0].D3).To(gomega.Equal(""))
+	g.Expect(list[0].D4).To(gomega.Equal(""))
 	// List detail level=2
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: 2})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(10))
 	g.Expect(list[0].Name).To(gomega.Equal("Elmer"))
-	g.Expect(list[0].Slice).To(gomega.BeNil())
+	g.Expect(len(list[0].Slice)).To(gomega.Equal(2))
+	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
+	g.Expect(list[0].D2).To(gomega.Equal("d-2"))
+	g.Expect(list[0].D3).To(gomega.Equal(""))
+	g.Expect(list[0].D4).To(gomega.Equal(""))
 	// List detail level=3
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: 3})
@@ -332,6 +350,9 @@ func TestList(t *testing.T) {
 	g.Expect(len(list)).To(gomega.Equal(10))
 	g.Expect(list[0].Name).To(gomega.Equal("Elmer"))
 	g.Expect(len(list[0].Slice)).To(gomega.Equal(2))
+	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
+	g.Expect(list[0].D2).To(gomega.Equal("d-2"))
+	g.Expect(list[0].D3).To(gomega.Equal("d-3"))
 	g.Expect(list[0].D4).To(gomega.Equal(""))
 	// List detail level=4
 	list = []TestObject{}
@@ -340,6 +361,9 @@ func TestList(t *testing.T) {
 	g.Expect(len(list)).To(gomega.Equal(10))
 	g.Expect(list[0].Name).To(gomega.Equal("Elmer"))
 	g.Expect(len(list[0].Slice)).To(gomega.Equal(2))
+	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
+	g.Expect(list[0].D2).To(gomega.Equal("d-2"))
+	g.Expect(list[0].D3).To(gomega.Equal("d-3"))
 	g.Expect(list[0].D4).To(gomega.Equal("d-4"))
 	// List = (single).
 	list = []TestObject{}
@@ -412,6 +436,7 @@ func TestList(t *testing.T) {
 		&list,
 		ListOptions{
 			Predicate: Gt("RowID", N/2),
+			Detail:    1,
 		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(N / 2))
@@ -422,6 +447,7 @@ func TestList(t *testing.T) {
 		&list,
 		ListOptions{
 			Predicate: Eq("RowID", Field{Name: "int8"}),
+			Detail:    1,
 		})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(len(list)).To(gomega.Equal(1))

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -20,7 +20,10 @@ import (
 )
 
 const (
+	// SQL tag.
 	Tag = "sql"
+	// Max detail level.
+	MaxDetail = 10
 )
 
 //
@@ -1383,18 +1386,20 @@ func (f *Field) Encoded() (encoded bool) {
 
 //
 // Detail level.
+// Defaults:
+//   0 = primary and natural fields.
+//   1 = other fields.
 func (f *Field) Detail() (level int) {
-	for n := 0; n < 10; n++ {
+	level = 1
+	for n := 0; n < MaxDetail; n++ {
 		if f.hasOpt(fmt.Sprintf("d%d", n)) {
-			return n
+			level = n
+			return
 		}
 	}
-	level = 2
-	if f.Pk() || f.Key() || f.Virtual() {
+	if f.Pk() || f.Key() {
 		level = 0
-	}
-	if f.Encoded() {
-		level = 3
+		return
 	}
 
 	return
@@ -1403,10 +1408,6 @@ func (f *Field) Detail() (level int) {
 //
 // Match detail level.
 func (f *Field) MatchDetail(level int) bool {
-	if level == 1 { // ALL
-		return true
-	}
-
 	return f.Detail() <= level
 }
 
@@ -1489,10 +1490,9 @@ type ListOptions struct {
 	// Sort by field position.
 	Sort []int
 	// Field detail level.
-	//   0 = core: pk; key and virtual fields.
-	//   1 = all fields.
-	//   2 = plain fields.
-	//   3 = encoded fields.
+	// Defaults:
+	//   0 = primary and natural fields.
+	//   1 = other fields.
 	Detail int
 	// Predicate
 	Predicate Predicate


### PR DESCRIPTION
Adjust (simplify) _model_ layer detail levels.
Level=1 no longer indicates all.
Default levels are 0 for keys and 1 for all other fields unless specified.