### PR TITLE
Better generated PK.

### DIFF
--- a/pkg/inventory/model/label.go
+++ b/pkg/inventory/model/label.go
@@ -7,7 +7,7 @@ type Labels map[string]string
 //
 // Label model
 type Label struct {
-	PK     string `sql:"pk"`
+	PK     string `sql:"pk(parent;kind;name)"`
 	Parent string `sql:"key"`
 	Kind   string `sql:"key"`
 	Name   string `sql:"key"`

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -19,10 +19,35 @@ type TestBase struct {
 	Phone  string `sql:""`
 }
 
+type PlainObject struct {
+	ID   int    `sql:"pk"`
+	Name string `sql:""`
+	Age  int    `sql:""`
+}
+
+func (m *PlainObject) Pk() string {
+	return fmt.Sprintf("%d", m.ID)
+}
+
+func (m *PlainObject) String() string {
+	return fmt.Sprintf(
+		"PlainObject: id: %d, name:%s",
+		m.ID,
+		m.Name)
+}
+
+func (m *PlainObject) Equals(other Model) bool {
+	return false
+}
+
+func (m *PlainObject) Labels() Labels {
+	return nil
+}
+
 type TestObject struct {
 	TestBase
 	RowID  int64          `sql:"virtual"`
-	PK     string         `sql:"pk,generated(id)"`
+	PK     string         `sql:"pk(id)"`
 	ID     int            `sql:"key"`
 	Name   string         `sql:"index(a)"`
 	Age    int            `sql:"index(a)"`
@@ -171,9 +196,26 @@ func TestCRUD(t *testing.T) {
 	DB := New(
 		"/tmp/test.db",
 		&Label{},
+		&PlainObject{},
 		&TestObject{})
 	err = DB.Open(true)
 	g.Expect(err).To(gomega.BeNil())
+
+	plainA := &PlainObject{
+		ID:   18,
+		Name: "Ashley",
+		Age:  17,
+	}
+	err = DB.Insert(plainA)
+	g.Expect(err).To(gomega.BeNil())
+	plainB := &PlainObject{ID: 18}
+	err = DB.Get(plainB)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(plainA.Pk()).To(gomega.Equal(plainB.Pk()))
+	g.Expect(plainA.ID).To(gomega.Equal(plainB.ID))
+	g.Expect(plainA.Name).To(gomega.Equal(plainB.Name))
+	g.Expect(plainA.Age).To(gomega.Equal(plainB.Age))
+
 	objA := &TestObject{
 		TestBase: TestBase{
 			Parent: 0,

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -332,7 +332,7 @@ func (t Table) Insert(model interface{}) error {
 	if err != nil {
 		return err
 	}
-	_ = t.SetPk(fields)
+	t.EnsurePk(fields)
 	stmt, err := t.insertSQL(t.Name(model), fields)
 	if err != nil {
 		return err
@@ -370,7 +370,7 @@ func (t Table) Update(model interface{}) error {
 	if err != nil {
 		return err
 	}
-	_ = t.SetPk(fields)
+	t.EnsurePk(fields)
 	stmt, err := t.updateSQL(t.Name(model), fields)
 	if err != nil {
 		return err
@@ -406,7 +406,7 @@ func (t Table) Delete(model interface{}) error {
 	if err != nil {
 		return err
 	}
-	_ = t.SetPk(fields)
+	t.EnsurePk(fields)
 	stmt, err := t.deleteSQL(t.Name(model), fields)
 	if err != nil {
 		return err
@@ -443,7 +443,7 @@ func (t Table) Get(model interface{}) error {
 	if err != nil {
 		return err
 	}
-	_ = t.SetPk(fields)
+	t.EnsurePk(fields)
 	stmt, err := t.getSQL(t.Name(model), fields)
 	if err != nil {
 		return err
@@ -692,24 +692,30 @@ func (t Table) Params(fields []*Field) []interface{} {
 }
 
 //
-// Set PK
-// Generated when not already set as sha1
-// of the (const) natural keys.
-func (t Table) SetPk(fields []*Field) error {
+// Ensure PK is generated as specified/needed.
+func (t Table) EnsurePk(fields []*Field) {
 	pk := t.PkField(fields)
 	if pk == nil {
-		return nil
+		return
+	}
+	withFields := pk.WithFields()
+	if len(withFields) == 0 {
+		return
 	}
 	switch pk.Value.Kind() {
 	case reflect.String:
 		if pk.Pull() != "" {
-			return nil
+			return
 		}
 	default:
-		return liberr.Wrap(GenPkTypeErr)
+		return
 	}
 	h := sha1.New()
-	for _, f := range t.KeyFields(fields) {
+	for _, f := range fields {
+		name := strings.ToLower(f.Name)
+		if matched, _ := withFields[name]; !matched {
+			continue
+		}
 		f.Pull()
 		switch f.Value.Kind() {
 		case reflect.String:
@@ -727,7 +733,6 @@ func (t Table) SetPk(fields []*Field) error {
 	}
 	pk.string = hex.EncodeToString(h.Sum(nil))
 	pk.Push()
-	return nil
 }
 
 //
@@ -981,6 +986,10 @@ func (t Table) scan(row Row, fields []*Field) error {
 }
 
 //
+// Regex used for `pk(fields)` tags.
+var PkRegex = regexp.MustCompile(`(pk)((\()(.+)(\)))?`)
+
+//
 // Regex used for `unique(group)` tags.
 var UniqueRegex = regexp.MustCompile(`(unique)(\()(.+)(\))`)
 
@@ -997,6 +1006,8 @@ var FkRegex = regexp.MustCompile(`(fk):(.+)(\()(.+)(\))`)
 // Tags:
 //   `sql:"pk"`
 //       The primary key.
+//   `sql:"pk(field;field;..)"`
+//       The generated primary key.
 //   `sql:"key"`
 //       The field is part of the natural key.
 //   `sql:"fk:T(F)"`
@@ -1031,12 +1042,15 @@ type Field struct {
 // Validate.
 func (f *Field) Validate() error {
 	switch f.Value.Kind() {
-	case reflect.String,
-		reflect.Int,
+	case reflect.String:
+	case reflect.Int,
 		reflect.Int8,
 		reflect.Int16,
 		reflect.Int32,
 		reflect.Int64:
+		if len(f.WithFields()) > 0 {
+			return liberr.Wrap(GenPkTypeErr)
+		}
 	default:
 		if f.Pk() {
 			return liberr.Wrap(PkTypeErr)
@@ -1201,8 +1215,39 @@ func (f *Field) Param() string {
 
 //
 // Get whether field is the primary key.
-func (f *Field) Pk() bool {
-	return f.hasOpt("pk")
+func (f *Field) Pk() (matched bool) {
+	for _, opt := range strings.Split(f.Tag, ",") {
+		m := PkRegex.FindStringSubmatch(opt)
+		if m != nil {
+			matched = true
+			break
+		}
+	}
+	return
+}
+
+//
+// Fields used to generate the primary key.
+// Map of lower-cased field names. May be empty
+// when generation is not enabled.
+func (f *Field) WithFields() (withFields map[string]bool) {
+	withFields = map[string]bool{}
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		m := PkRegex.FindStringSubmatch(opt)
+		if m != nil && len(m) == 6 {
+			for _, name := range strings.Split(m[4], ";") {
+				name = strings.TrimSpace(name)
+				if len(name) > 0 {
+					name = strings.ToLower(name)
+					withFields[name] = true
+				}
+			}
+		}
+		break
+	}
+
+	return
 }
 
 //


### PR DESCRIPTION
Better derived PK.  Modeler more explicitly defines if/how PK is derived.
Currently the PK is derived using the _natural_ key fields any time the field is blank which can result in operations on models using a non-deterministic PK.  And/or report errors when the PK is black as the generated (incorrect) key.