### PR TITLE
Add container.Collection.

### DIFF
--- a/pkg/inventory/container/collection.go
+++ b/pkg/inventory/container/collection.go
@@ -1,0 +1,269 @@
+/*
+A collection of models.
+Provides methods to reconcile the collection of stored models
+with the collection of desired models.
+*/
+package container
+
+import (
+	fb "github.com/konveyor/controller/pkg/filebacked"
+	"github.com/konveyor/controller/pkg/inventory/model"
+	"reflect"
+)
+
+//
+// Model shepherd.
+type Shepherd interface {
+	// Determine if model needs to be updated.
+	Equals(mA, mB model.Model) bool
+	// Update the stored model as desired.
+	Update(stored, desired model.Model)
+}
+
+//
+// Disposition.
+type Disposition struct {
+	// The stored models in the collection.
+	stored model.Model
+	// The desired models in the collection.
+	desired model.Model
+}
+
+//
+// Disposition map.
+type Dispositions map[string]*Disposition
+
+//
+// Model collection.
+type Collection struct {
+	// Stored models.
+	Stored fb.Iterator
+	// DB transaction.
+	Tx *model.Tx
+	// An (optional) shepherd.
+	Shepherd Shepherd
+	// Number of models added.
+	Added int
+	// Number models updated.
+	Updated int
+	// Number models deleted.
+	Deleted int
+}
+
+//
+// Add models included in desired but not stored.
+func (r *Collection) Add(desired fb.Iterator) (err error) {
+	mp, err := r.dispositions(desired)
+	if err == nil {
+		err = r.add(mp)
+	}
+
+	return
+}
+
+//
+// Update models.
+func (r *Collection) Update(desired fb.Iterator) (err error) {
+	mp, err := r.dispositions(desired)
+	if err == nil {
+		err = r.update(mp)
+	}
+
+	return
+}
+
+//
+// Delete stored models not included in the desired.
+func (r *Collection) Delete(desired fb.Iterator) (err error) {
+	mp, err := r.dispositions(desired)
+	if err == nil {
+		err = r.delete(mp)
+	}
+
+	return
+}
+
+//
+// Reconcile the collection.
+// Ensure the stored collection is as desired.
+func (r *Collection) Reconcile(desired fb.Iterator) (err error) {
+	mp, err := r.dispositions(desired)
+	err = r.delete(mp)
+	if err != nil {
+		return
+	}
+	err = r.add(mp)
+	if err != nil {
+		return
+	}
+	err = r.update(mp)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+//
+// Build the dispositions.
+func (r *Collection) dispositions(desired fb.Iterator) (mp map[string]*Disposition, err error) {
+	mp = map[string]*Disposition{}
+	for {
+		object, hasNext, iErr := r.Stored.Next()
+		if iErr != nil {
+			err = iErr
+			return
+		}
+		if !hasNext {
+			break
+		}
+		m := object.(model.Model)
+		mp[m.Pk()] = &Disposition{
+			stored: m,
+		}
+	}
+	for {
+		object, hasNext, iErr := desired.Next()
+		if iErr != nil {
+			err = iErr
+			return
+		}
+		if !hasNext {
+			break
+		}
+		m := object.(model.Model)
+		if dpn, found := mp[m.Pk()]; !found {
+			mp[m.Pk()] = &Disposition{
+				desired: m,
+			}
+		} else {
+			dpn.desired = m
+		}
+	}
+
+	return
+}
+
+//
+// Add models included in desired but not stored.
+func (r *Collection) add(dispositions Dispositions) (err error) {
+	for _, dpn := range dispositions {
+		if dpn.desired != nil && dpn.stored == nil {
+			err = r.Tx.Insert(dpn.desired)
+			if err == nil {
+				r.Added++
+			} else {
+				return
+			}
+		}
+	}
+
+	return
+}
+
+//
+// Update models.
+func (r *Collection) update(dispositions Dispositions) (err error) {
+	shepherd := r.Shepherd
+	if shepherd == nil {
+		shepherd = &DefaultShepherd{}
+	}
+	for _, dpn := range dispositions {
+		if dpn.desired == nil || dpn.stored == nil {
+			continue
+		}
+		if shepherd.Equals(dpn.desired, dpn.stored) {
+			continue
+		}
+		shepherd.Update(dpn.stored, dpn.desired)
+		err = r.Tx.Update(dpn.stored)
+		if err == nil {
+			r.Updated++
+		} else {
+			return
+		}
+	}
+
+	return
+}
+
+//
+// Delete stored models not included in the desired.
+func (r *Collection) delete(dispositions Dispositions) (err error) {
+	for _, dpn := range dispositions {
+		if dpn.stored != nil && dpn.desired == nil {
+			err = r.Tx.Delete(dpn.stored)
+			if err == nil {
+				r.Deleted++
+			} else {
+				return
+			}
+		}
+	}
+
+	return
+}
+
+//
+// Default (reflect-based) shepherd.
+// Fields are ignored when:
+//   - Is the PK.
+//   - Is (auto) incremented.
+//   - Has the `eq:"-"` tag.
+type DefaultShepherd struct {
+}
+
+//
+// Model comparison.
+func (r *DefaultShepherd) Equals(mA, mB model.Model) bool {
+	fieldsA, _ := model.Table{}.Fields(mA)
+	fieldsB, _ := model.Table{}.Fields(mB)
+	for i := 0; i < len(fieldsA); i++ {
+		fA := fieldsA[i]
+		fB := fieldsB[i]
+		if r.ignored(fA) {
+			continue
+		}
+		vA := fA.Value.Interface()
+		vB := fB.Value.Interface()
+		if !reflect.DeepEqual(vA, vB) {
+			return false
+		}
+	}
+
+	return true
+}
+
+//
+// Update model A (stored) with model B (desired).
+func (r *DefaultShepherd) Update(mA, mB model.Model) {
+	fieldsA, _ := model.Table{}.Fields(mA)
+	fieldsB, _ := model.Table{}.Fields(mB)
+	for i := 0; i < len(fieldsA); i++ {
+		fA := fieldsA[i]
+		fB := fieldsB[i]
+		if r.ignored(fA) {
+			continue
+		}
+		vB := fB.Value.Interface()
+		fA.Value.Set(reflect.ValueOf(vB))
+	}
+}
+
+//
+// The field is ignored when:
+//   - Is the PK.
+//   - Is (auto) incremented.
+//   - Has the `eq:"-"` tag.
+func (r *DefaultShepherd) ignored(f *model.Field) bool {
+	if f.Pk() || f.Incremented() {
+		return true
+	}
+	if tag, found := f.Type.Tag.Lookup("eq"); found {
+		if tag == "-" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/inventory/container/collection_test.go
+++ b/pkg/inventory/container/collection_test.go
@@ -1,0 +1,192 @@
+package container
+
+import (
+	"errors"
+	fb "github.com/konveyor/controller/pkg/filebacked"
+	"github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/onsi/gomega"
+	"strconv"
+	"testing"
+)
+
+type TestObject2 struct {
+	ID       int    `sql:"pk"`
+	Revision int    `sql:"incremented"`
+	Name     string `sql:""`
+	Age      int    `sql:""`
+}
+
+func (r *TestObject2) Pk() string {
+	return strconv.Itoa(r.ID)
+}
+
+func TestCollection(t *testing.T) {
+	var err error
+	g := gomega.NewGomegaWithT(t)
+	DB := model.New("/tmp/test2.db", &TestObject2{})
+	err = DB.Open(true)
+	g.Expect(err).To(gomega.BeNil())
+
+	desired := []TestObject2{}
+	for i := 0; i < 10; i++ {
+		m := TestObject2{
+			ID:   i,
+			Name: strconv.Itoa(i),
+			Age:  i,
+		}
+		err = DB.Insert(&m)
+		g.Expect(err).To(gomega.BeNil())
+		desired = append(desired, m)
+		g.Expect(err).To(gomega.BeNil())
+	}
+
+	//
+	// Test nothing changed.
+	stored, err := DB.Iter(
+		&TestObject2{},
+		model.ListOptions{
+			Detail: model.MaxDetail,
+		})
+	g.Expect(err).To(gomega.BeNil())
+	collection := Collection{
+		Stored: stored,
+	}
+	err = collection.Reconcile(asIter(desired))
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(collection.Added).To(gomega.Equal(0))
+	g.Expect(collection.Updated).To(gomega.Equal(0))
+	g.Expect(collection.Deleted).To(gomega.Equal(0))
+
+	//
+	// Test adds.
+	stored, err = DB.Iter(
+		&TestObject2{},
+		model.ListOptions{
+			Detail: model.MaxDetail,
+		})
+	for i := 11; i < 15; i++ {
+		desired = append(
+			desired, TestObject2{
+				ID:   i,
+				Name: strconv.Itoa(i),
+				Age:  i,
+			})
+	}
+	tx, _ := DB.Begin()
+	defer func() {
+		_ = tx.End()
+	}()
+	collection = Collection{
+		Stored: stored,
+		Tx:     tx,
+	}
+	err = collection.Add(asIter(desired))
+	_ = tx.Commit()
+	g.Expect(collection.Added).To(gomega.Equal(4))
+	g.Expect(collection.Updated).To(gomega.Equal(0))
+	g.Expect(collection.Deleted).To(gomega.Equal(0))
+
+	//
+	// Test updates.
+	stored, err = DB.Iter(
+		&TestObject2{},
+		model.ListOptions{
+			Detail: model.MaxDetail,
+		})
+	desired[6].Name = "Larry"
+	desired[8].Age = 100
+	tx, _ = DB.Begin()
+	defer func() {
+		_ = tx.End()
+	}()
+	collection = Collection{
+		Stored: stored,
+		Tx:     tx,
+	}
+	err = collection.Update(asIter(desired))
+	_ = tx.Commit()
+	g.Expect(collection.Added).To(gomega.Equal(0))
+	g.Expect(collection.Updated).To(gomega.Equal(2))
+	g.Expect(collection.Deleted).To(gomega.Equal(0))
+	updated := &TestObject2{ID: 6}
+	err = DB.Get(updated)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(updated.Name).To(gomega.Equal("Larry"))
+	updated = &TestObject2{ID: 8}
+	err = DB.Get(updated)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(updated.Age).To(gomega.Equal(100))
+
+	//
+	// Test deletes.
+	stored, err = DB.Iter(
+		&TestObject2{},
+		model.ListOptions{
+			Detail: model.MaxDetail,
+		})
+	desired = desired[2:]
+	tx, _ = DB.Begin()
+	defer func() {
+		_ = tx.End()
+	}()
+	collection = Collection{
+		Stored: stored,
+		Tx:     tx,
+	}
+	err = collection.Delete(asIter(desired))
+	_ = tx.Commit()
+	g.Expect(collection.Added).To(gomega.Equal(0))
+	g.Expect(collection.Updated).To(gomega.Equal(0))
+	g.Expect(collection.Deleted).To(gomega.Equal(2))
+	deleted := &TestObject2{ID: 0}
+	err = DB.Get(deleted)
+	g.Expect(errors.Is(err, model.NotFound)).To(gomega.BeTrue())
+	updated = &TestObject2{ID: 1}
+	err = DB.Get(deleted)
+	g.Expect(errors.Is(err, model.NotFound)).To(gomega.BeTrue())
+
+	// Test reconcile.
+	stored, err = DB.Iter(
+		&TestObject2{},
+		model.ListOptions{
+			Detail: model.MaxDetail,
+		})
+	// delete
+	desired = desired[2:]
+	// update
+	desired[3].Name = "Ashley"
+	desired[5].Name = "Courtney"
+	// add
+	for i := 15; i < 20; i++ {
+		desired = append(
+			desired, TestObject2{
+				ID:   i,
+				Name: strconv.Itoa(i),
+				Age:  i,
+			})
+	}
+	tx, _ = DB.Begin()
+	defer func() {
+		_ = tx.End()
+	}()
+	collection = Collection{
+		Stored: stored,
+		Tx:     tx,
+	}
+	err = collection.Reconcile(asIter(desired))
+	_ = tx.Commit()
+	g.Expect(collection.Added).To(gomega.Equal(5))
+	g.Expect(collection.Updated).To(gomega.Equal(2))
+	g.Expect(collection.Deleted).To(gomega.Equal(2))
+}
+
+//
+// Iterator of models.
+func asIter(models []TestObject2) fb.Iterator {
+	list := fb.NewList()
+	for _, m := range models {
+		_ = list.Append(m)
+	}
+
+	return list.Iter()
+}

--- a/pkg/inventory/container/ocp/reconciler.go
+++ b/pkg/inventory/container/ocp/reconciler.go
@@ -412,7 +412,7 @@ func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 			rl.log.V(3).Info(
 				"model created.",
 				ref.ToKind(r.model),
-				r.model.String())
+				libmodel.Describe(r.model))
 		}
 	case 0x02: // Update
 		if version > rl.versionThreshold {
@@ -423,7 +423,7 @@ func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 			rl.log.V(3).Info(
 				"model updated.",
 				ref.ToKind(r.model),
-				r.model.String())
+				libmodel.Describe(r.model))
 		}
 	case 0x04: // Delete
 		err = tx.Delete(r.model)
@@ -433,7 +433,7 @@ func (r *ModelEvent) Apply(rl *Reconciler) (err error) {
 		rl.log.V(3).Info(
 			"model deleted.",
 			ref.ToKind(r.model),
-			r.model.String())
+			libmodel.Describe(r.model))
 	default:
 		return liberr.New(
 			"unknown action",

--- a/pkg/inventory/model/journal.go
+++ b/pkg/inventory/model/journal.go
@@ -59,7 +59,7 @@ func (r *Event) String() string {
 	}
 	model := ""
 	if r.Model != nil {
-		model = r.Model.String()
+		model = Describe(r.Model)
 	}
 	return fmt.Sprintf(
 		"event-%.4d: %s model=%s",

--- a/pkg/inventory/model/model.go
+++ b/pkg/inventory/model/model.go
@@ -76,12 +76,12 @@ func (p *Page) Slice(collection interface{}) {
 type Model interface {
 	// Get the primary key.
 	Pk() string
-	// Get description of the model.
-	String() string
-	// Equal comparison.
-	Equals(other Model) bool
+}
+
+//
+// Labeled model.
+type Labeled interface {
 	// Get labels.
-	// Optional and may return nil.
 	Labels() Labels
 }
 
@@ -115,6 +115,13 @@ func Clone(model Model) Model {
 
 //
 // Model description.
-func Describe(model Model) string {
-	return ref.ToKind(model) + ": " + model.String()
+func Describe(model Model) (s string) {
+	s = ref.ToKind(model) + ": "
+	if hasStr, cast := model.(interface{ String() string }); cast {
+		s += hasStr.String()
+	} else {
+		s += model.Pk()
+	}
+
+	return
 }

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -76,10 +76,6 @@ func (m *TestObject) String() string {
 		m.Name)
 }
 
-func (m *TestObject) Equals(other Model) bool {
-	return false
-}
-
 func (m *TestObject) Labels() Labels {
 	return m.labels
 }


### PR DESCRIPTION
Add the `Collection` to the _container_ package.
Provides reconciliation of a collection of stored models based on a collection of desired models.

Add the `sql:"incremented"` tag for _auto-incremented_ fields.

Relaxed the `Model` interface.  Equals(), Labels() and String() no longer required.  The Labels() and String() are now optional.