### PR TITLE
Simpler filebacked API; no longer return error.

### DIFF
--- a/pkg/filebacked/iterator.go
+++ b/pkg/filebacked/iterator.go
@@ -6,11 +6,9 @@ type Iterator interface {
 	// Length.
 	Len() int
 	// Next object.
-	Next() (interface{}, bool, error)
+	Next() (interface{}, bool)
 	// Next object.
-	NextWith(object interface{}) (bool, error)
-	// Get associated error.
-	Error() error
+	NextWith(object interface{}) bool
 	// Close the iterator.
 	Close()
 }
@@ -28,20 +26,14 @@ func (*EmptyIterator) Len() int {
 
 //
 // Next object.
-func (*EmptyIterator) Next() (interface{}, bool, error) {
-	return nil, false, nil
+func (*EmptyIterator) Next() (interface{}, bool) {
+	return nil, false
 }
 
 //
 // Next object.
-func (*EmptyIterator) NextWith(object interface{}) (bool, error) {
-	return false, nil
-}
-
-//
-// Get associated error.
-func (*EmptyIterator) Error() error {
-	return nil
+func (*EmptyIterator) NextWith(object interface{}) bool {
+	return false
 }
 
 //

--- a/pkg/filebacked/list.go
+++ b/pkg/filebacked/list.go
@@ -7,16 +7,24 @@ list := fb.NewList()
 
 //
 // Append an object.
-err := list.Append(object)
+list.Append(object)
 
 //
 // Iterate the list.
 itr := list.Iter()
 for {
-    object, hasNext, err := itr.Next()
-    if err != nil || !hasNext {
+    object, hasNext := itr.Next()
+    if !hasNext {
         break
     }
+    ...
+}
+
+//
+// Iterate the list.
+itr := list.Iter()
+for object, hasNext := itr.Next(); hasNext; object, hasNext = itr.Next() {
+    ...
 }
 
 //
@@ -24,10 +32,11 @@ for {
 itr := list.Iter()
 for {
     person := Person{}
-    hasNext, err := itr.NextWith(&person))
-    if err != nil || !hasNext {
+    hasNext := itr.NextWith(&person))
+    if !hasNext {
         break
     }
+    ...
 }
 */
 package filebacked
@@ -55,9 +64,8 @@ type List struct {
 
 //
 // Append an object.
-func (l *List) Append(object interface{}) (err error) {
-	err = l.writer.Append(object)
-	return
+func (l *List) Append(object interface{}) {
+	l.writer.Append(object)
 }
 
 //

--- a/pkg/filebacked/list_test.go
+++ b/pkg/filebacked/list_test.go
@@ -50,8 +50,7 @@ func TestList(t *testing.T) {
 
 	// append
 	for i := 0; i < len(input); i++ {
-		err := list.Append(input[i])
-		g.Expect(err).To(gomega.BeNil())
+		list.Append(input[i])
 	}
 	g.Expect(len(cat.content)).To(gomega.Equal(2))
 	g.Expect(list.writer.length).To(gomega.Equal(uint64(len(input))))
@@ -61,8 +60,7 @@ func TestList(t *testing.T) {
 	itr := list.Iter()
 	g.Expect(itr.Len()).To(gomega.Equal(len(input)))
 	for i := 0; i < len(input); i++ {
-		object, hasNext, err := itr.Next()
-		g.Expect(err).To(gomega.BeNil())
+		object, hasNext := itr.Next()
 		g.Expect(object).ToNot(gomega.BeNil())
 		g.Expect(hasNext).To(gomega.BeTrue())
 		g.Expect(itr.Len()).To(gomega.Equal(len(input)))
@@ -70,36 +68,30 @@ func TestList(t *testing.T) {
 
 	n := 0
 	itr = list.Iter()
-	g.Expect(itr.Error()).To(gomega.BeNil())
 	for {
-		object, hasNext, err := itr.Next()
-		g.Expect(err).To(gomega.BeNil())
+		object, hasNext := itr.Next()
 		if hasNext {
 			n++
 		} else {
 			break
 		}
 		g.Expect(object).ToNot(gomega.BeNil())
-		g.Expect(err).To(gomega.BeNil())
 		g.Expect(hasNext).To(gomega.BeTrue())
 	}
 	g.Expect(n).To(gomega.Equal(len(input)))
 
 	n = 0
 	itr = list.Iter()
-	g.Expect(itr.Error()).To(gomega.BeNil())
 	for {
 		person := &Person{}
-		hasNext, err := itr.NextWith(person)
-		g.Expect(err).To(gomega.BeNil())
+		hasNext := itr.NextWith(person)
 		if hasNext {
 			n++
 		} else {
 			break
 		}
 		user := &User{}
-		hasNext, err = itr.NextWith(user)
-		g.Expect(err).To(gomega.BeNil())
+		hasNext = itr.NextWith(user)
 		if hasNext {
 			n++
 		} else {
@@ -107,7 +99,6 @@ func TestList(t *testing.T) {
 		}
 		g.Expect(person).ToNot(gomega.BeNil())
 		g.Expect(user).ToNot(gomega.BeNil())
-		g.Expect(err).To(gomega.BeNil())
 		g.Expect(hasNext).To(gomega.BeTrue())
 	}
 	g.Expect(n).To(gomega.Equal(len(input)))

--- a/pkg/inventory/container/collection_test.go
+++ b/pkg/inventory/container/collection_test.go
@@ -185,7 +185,7 @@ func TestCollection(t *testing.T) {
 func asIter(models []TestObject2) fb.Iterator {
 	list := fb.NewList()
 	for _, m := range models {
-		_ = list.Append(m)
+		list.Append(m)
 	}
 
 	return list.Iter()

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -579,12 +579,12 @@ func TestIter(t *testing.T) {
 	var list []TestObject
 	for {
 		object := TestObject{}
-		hasNext, err := itr.NextWith(&object)
-		if !hasNext {
+		if itr.NextWith(&object) {
+			g.Expect(err).To(gomega.BeNil())
+			list = append(list, object)
+		} else {
 			break
 		}
-		g.Expect(err).To(gomega.BeNil())
-		list = append(list, object)
 	}
 	g.Expect(len(list)).To(gomega.Equal(10))
 	// List all; detail level=0
@@ -592,12 +592,8 @@ func TestIter(t *testing.T) {
 		&TestObject{},
 		ListOptions{})
 	g.Expect(err).To(gomega.BeNil())
-	for {
-		object, hasNext, err := itr.Next()
+	for object, hasNext := itr.Next(); hasNext; object, hasNext = itr.Next() {
 		g.Expect(err).To(gomega.BeNil())
-		if !hasNext {
-			break
-		}
 		_, cast := object.(Model)
 		g.Expect(cast).To(gomega.BeTrue())
 	}

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -563,11 +563,7 @@ func (t Table) Iter(model interface{}, options ListOptions) (itr fb.Iterator, er
 			err = liberr.Wrap(err)
 			return
 		}
-		err = list.Append(mPtr.Interface())
-		if err != nil {
-			err = liberr.Wrap(err)
-			return
-		}
+		list.Append(mPtr.Interface())
 	}
 
 	itr = list.Iter()


### PR DESCRIPTION
The filebacked object methods no longer return error but panic instead.
The root cause of I/O and serialization errors are not situational or recoverable.

Also add Event.append() and Event.next() to encapsulate the _protocol_ for writing/reading event from the filebacked list.