### PR TITLE
Reflect auto-incremented fields in created/updated model.

### DIFF
--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -49,6 +49,7 @@ type TestObject struct {
 	RowID  int64          `sql:"virtual"`
 	PK     string         `sql:"pk(id)"`
 	ID     int            `sql:"key"`
+	Rev    int            `sql:"incremented"`
 	Name   string         `sql:"index(a)"`
 	Age    int            `sql:"index(a)"`
 	Int8   int8           `sql:""`
@@ -238,6 +239,7 @@ func TestCRUD(t *testing.T) {
 	assertEqual := func(a, b *TestObject) {
 		g.Expect(a.PK).To(gomega.Equal(b.PK))
 		g.Expect(a.ID).To(gomega.Equal(b.ID))
+		g.Expect(a.Rev).To(gomega.Equal(b.Rev))
 		g.Expect(a.Name).To(gomega.Equal(b.Name))
 		g.Expect(a.Age).To(gomega.Equal(b.Age))
 		g.Expect(a.Int8).To(gomega.Equal(b.Int8))
@@ -260,6 +262,7 @@ func TestCRUD(t *testing.T) {
 	// Insert
 	err = DB.Insert(objA)
 	g.Expect(err).To(gomega.BeNil())
+	g.Expect(objA.Rev).To(gomega.Equal(1))
 	objB := &TestObject{ID: objA.ID}
 	// Get
 	err = DB.Get(objB)

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -355,6 +355,8 @@ func (t Table) Insert(model interface{}) error {
 		return liberr.Wrap(err)
 	}
 
+	t.reflectIncremented(fields)
+
 	log.V(5).Info(
 		"table: model inserted.",
 		"sql",
@@ -390,6 +392,8 @@ func (t Table) Update(model interface{}) error {
 	if nRows == 0 {
 		return liberr.Wrap(NotFound)
 	}
+
+	t.reflectIncremented(fields)
 
 	log.V(5).Info(
 		"table: model updated.",
@@ -818,6 +822,18 @@ func (t Table) Constraints(fields []*Field) []string {
 	}
 
 	return constraints
+}
+
+//
+// Reflect auto-incremented fields.
+// Field.int is incremented by Field.Push() called when the
+// SQL statement is built. This needs to be propagated to the model.
+func (t *Table) reflectIncremented(fields []*Field) {
+	for _, f := range fields {
+		if f.Incremented() {
+			f.Value.SetInt(f.int)
+		}
+	}
 }
 
 //


### PR DESCRIPTION
Reflect auto-incremented fields in created/updated model.  This is mainly needed so that models delivered by the watch (system) will accurately reflect the value.

Also, added a unit test for auto-incremented fields.