### PR TITLE
Direct indexing

### DIFF
--- a/pkg/filebacked/iterator.go
+++ b/pkg/filebacked/iterator.go
@@ -2,15 +2,53 @@ package filebacked
 
 //
 // Iterator.
+// Read-only collection with stateful iteration.
 type Iterator interface {
-	// Length.
+	// Number of items.
 	Len() int
+	// Object at index.
+	At(index int) interface{}
+	// Object at index (with).
+	AtWith(int, interface{})
 	// Next object.
 	Next() (interface{}, bool)
-	// Next object.
+	// Next object (with).
 	NextWith(object interface{}) bool
 	// Close the iterator.
 	Close()
+}
+
+//
+// Iterator.
+type FbIterator struct {
+	// Reader.
+	*Reader
+	// Current position.
+	current int
+}
+
+//
+// Next object.
+func (r *FbIterator) Next() (object interface{}, hasNext bool) {
+	if r.current < r.Len() {
+		object = r.At(r.current)
+		r.current++
+		hasNext = true
+	}
+
+	return
+}
+
+//
+// Next object.
+func (r *FbIterator) NextWith(object interface{}) (hasNext bool) {
+	if r.current < r.Len() {
+		r.AtWith(r.current, object)
+		r.current++
+		hasNext = true
+	}
+
+	return
 }
 
 //
@@ -22,6 +60,16 @@ type EmptyIterator struct {
 // Length.
 func (*EmptyIterator) Len() int {
 	return 0
+}
+
+// Object at index.
+func (*EmptyIterator) At(int) interface{} {
+	return nil
+}
+
+// Object at index.
+func (*EmptyIterator) AtWith(int, interface{}) {
+	return
 }
 
 //

--- a/pkg/filebacked/list.go
+++ b/pkg/filebacked/list.go
@@ -12,6 +12,23 @@ list.Append(object)
 //
 // Iterate the list.
 itr := list.Iter()
+for i := 0; i < itr.Len(); i++ {
+    person := itr.At(i)
+    ...
+}
+
+//
+// Iterate the list.
+itr := list.Iter()
+for i := 0; i < itr.Len(); i++ {
+    person := Person{}
+    itr.AtWith(i, &person))
+    ...
+}
+
+//
+// Iterate the list.
+itr := list.Iter()
 for {
     object, hasNext := itr.Next()
     if !hasNext {
@@ -41,7 +58,9 @@ for {
 */
 package filebacked
 
-import "runtime"
+import (
+	"runtime"
+)
 
 //
 // List factory.
@@ -72,14 +91,30 @@ func (l *List) Append(object interface{}) {
 // Length.
 // Number of objects.
 func (l *List) Len() int {
-	return int(l.writer.length)
+	return len(l.writer.index)
+}
+
+// Object at index.
+func (l *List) At(index int) (object interface{}) {
+	reader := l.writer.Reader(true)
+	object = reader.At(index)
+	return
+}
+
+// Object at index.
+func (l *List) AtWith(index int, object interface{}) {
+	reader := l.writer.Reader(true)
+	reader.AtWith(index, object)
+	return
 }
 
 //
 // Get an iterator.
 func (l *List) Iter() (itr Iterator) {
 	if l.Len() > 0 {
-		itr = l.writer.Reader()
+		itr = &FbIterator{
+			Reader: l.writer.Reader(false),
+		}
 	} else {
 		itr = &EmptyIterator{}
 	}


### PR DESCRIPTION
Add direct-indexed access to the `filebacked.Iterator`.
List example:
```
for i := 0; i < list.Len(); i++ {
    object := list.At(i)
}
```
```
for i := 0; i < list.Len(); i++ {
    object := <thing>
    list.AtWith(i, &object))
}
```
Iterator example:
```
itr := list.Iter()
for i := 0; i < itr.Len(); i++ {
    object := itr.At(i)
}
```
```
itr := list.Iter()
for i := 0; i < itr.Len(); i++ {
    object := <thing>
    itr.AtWith(i, &object))
}
```

The filebacked API reorganized to promote direct access in favor of Next() and NextWith().
The open() on both `Reader` and `Writer` could be simplified to panic instead of return error.
The `Reader` could be simplified to only support At() and AtWith().
Introduced the concept of a _shared_ reader to efficiently support At() and AtWith() read operations on `List`.
The `Writer.Append()` seek to end.  This is safer given the `List` will support both write and read operations.
Create the `FbIterator` layered on top of the `Reader`.  The iterator (impl) needs to store the current position for Next() and NextWith() operators instead of relying on the `Reader.file` position.  This makes it safe to use the iterator for mixed direct/non-direct access opterations. 

---

Update the `container.Collection disposition` (map) to store the index instead of the actual stored and desired models in memory.  This **greatly** reduces the memory footprint.

Update the model package to direct-access API to eliminate _naked_ for {}.