### PR TITLE
Minor Model Enhancements

### DIFF
--- a/pkg/filebacked/file.go
+++ b/pkg/filebacked/file.go
@@ -1,7 +1,6 @@
 /*
 File backing for collections.
 File format:
-   Length: 8 (uint64)
    | kind: 2 (uint16)
    | size: 8 (uint64)
    | object: n (gob encoded)

--- a/pkg/inventory/container/collection_test.go
+++ b/pkg/inventory/container/collection_test.go
@@ -42,7 +42,7 @@ func TestCollection(t *testing.T) {
 
 	//
 	// Test nothing changed.
-	stored, err := DB.Iter(
+	stored, err := DB.Find(
 		&TestObject2{},
 		model.ListOptions{
 			Detail: model.MaxDetail,
@@ -59,7 +59,7 @@ func TestCollection(t *testing.T) {
 
 	//
 	// Test adds.
-	stored, err = DB.Iter(
+	stored, err = DB.Find(
 		&TestObject2{},
 		model.ListOptions{
 			Detail: model.MaxDetail,
@@ -88,7 +88,7 @@ func TestCollection(t *testing.T) {
 
 	//
 	// Test updates.
-	stored, err = DB.Iter(
+	stored, err = DB.Find(
 		&TestObject2{},
 		model.ListOptions{
 			Detail: model.MaxDetail,
@@ -119,7 +119,7 @@ func TestCollection(t *testing.T) {
 
 	//
 	// Test deletes.
-	stored, err = DB.Iter(
+	stored, err = DB.Find(
 		&TestObject2{},
 		model.ListOptions{
 			Detail: model.MaxDetail,
@@ -146,7 +146,7 @@ func TestCollection(t *testing.T) {
 	g.Expect(errors.Is(err, model.NotFound)).To(gomega.BeTrue())
 
 	// Test reconcile.
-	stored, err = DB.Iter(
+	stored, err = DB.Find(
 		&TestObject2{},
 		model.ListOptions{
 			Detail: model.MaxDetail,

--- a/pkg/inventory/model/client.go
+++ b/pkg/inventory/model/client.go
@@ -23,8 +23,8 @@ type DB interface {
 	Get(Model) error
 	// List models based on the type of slice.
 	List(interface{}, ListOptions) error
-	// List models.
-	Iter(interface{}, ListOptions) (fb.Iterator, error)
+	// Find models.
+	Find(interface{}, ListOptions) (fb.Iterator, error)
 	// Count based on the specified model.
 	Count(Model, Predicate) (int64, error)
 	// Begin a transaction.
@@ -164,12 +164,12 @@ func (r *Client) List(list interface{}, options ListOptions) (err error) {
 }
 
 //
-// List models.
-func (r *Client) Iter(model interface{}, options ListOptions) (itr fb.Iterator, err error) {
+// Find models.
+func (r *Client) Find(model interface{}, options ListOptions) (itr fb.Iterator, err error) {
 	session := r.pool.Reader()
 	defer session.Return()
 	mark := time.Now()
-	itr, err = Table{session.db}.Iter(model, options)
+	itr, err = Table{session.db}.Find(model, options)
 	if err == nil {
 		r.log.V(4).Info(
 			"list succeeded.",
@@ -309,7 +309,7 @@ func (r *Client) Watch(model Model, handler EventHandler) (w *Watch, err error) 
 	options := handler.Options()
 	var snapshot fb.Iterator
 	if options.Snapshot {
-		snapshot, err = r.Iter(model, ListOptions{Detail: 1})
+		snapshot, err = r.Find(model, ListOptions{Detail: 1})
 		if err != nil {
 			return
 		}
@@ -451,9 +451,9 @@ func (r *Tx) List(list interface{}, options ListOptions) (err error) {
 
 //
 // List models.
-func (r *Tx) Iter(model interface{}, options ListOptions) (itr fb.Iterator, err error) {
+func (r *Tx) Find(model interface{}, options ListOptions) (itr fb.Iterator, err error) {
 	mark := time.Now()
-	itr, err = Table{r.real}.Iter(model, options)
+	itr, err = Table{r.real}.Find(model, options)
 	if err == nil {
 		r.log.V(4).Info(
 			"iter succeeded",

--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -3,8 +3,12 @@
 // needs of the `container` package.
 // Each entity (table) is modeled by a struct.  Each field (column)
 // is Described using tags:
+//    sql: "-"
+//       The field is omitted.
 //   `sql:"pk"`
 //       The primary key.
+//   `sql:"pk(field;field;..)"`
+//       The generated primary key.
 //   `sql:"key"`
 //       The field is part of the natural key.
 //   `sql:"fk:T(F)"`
@@ -19,6 +23,9 @@
 //       The field is read-only and managed internally by the DB.
 //   `sql:"dn"`
 //       The field detail level.  n = level number (0-9).
+//   `sql:incremented`
+//       The field is auto-incremented.
+//
 // Each struct must implement the `Model` interface.
 // Basic CRUD operations may be performed on each model using
 // the `DB` interface which together with the `Model` interface
@@ -31,13 +38,12 @@
 //       ID    string `sql:"pk"`
 //       First string `sql:"key"`
 //       Last  string `sql:"key"
-//       Age   int    `sql:""`
+//       Age   int
 //   }
 //
-//   func (p *Person) Pk() string {...}
-//   func (p *Person) Equals(other Model) bool {...}
-//   func (p *Person) Labels() {...}
-//   func (p *Person) String() string {...}
+//   func (p *Person) Pk() string {
+//       return p.ID
+//   }
 //
 // Insert the model:
 //   person := &Person{


### PR DESCRIPTION
Add support for `sql:"-"` to omit fields.
The `sql:""` tag is optional.  All fields will be included by default unless omitted.  Fields of type _struct_ will be aggregated unless an explicitly tagged.
Renamed Client.Iter() and Table.Iter() to Find().  Better to be a verb and more consistent with other methods.

Added unit tests.
Ensure all unit tests use their own DB.