### PR TITLE
Improved model concurrency.

### DIFF
--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -124,9 +124,6 @@ func New(path string, models ...interface{}) DB {
 	client.journal.log = logging.WithName("db|journal").WithValues(
 		"db",
 		path)
-	client.labeler.log = logging.WithName("db|labeler").WithValues(
-		"db",
-		path)
 
 	return client
 }

--- a/pkg/inventory/model/model.go
+++ b/pkg/inventory/model/model.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/controller/pkg/ref"
-	_ "github.com/mattn/go-sqlite3"
 	"reflect"
 )
 

--- a/pkg/inventory/model/session.go
+++ b/pkg/inventory/model/session.go
@@ -1,0 +1,170 @@
+package model
+
+import (
+	"database/sql"
+	liberr "github.com/konveyor/controller/pkg/error"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+//
+// DB session.
+// Encapsulates the sql.DB.
+type Session struct {
+	// ID.
+	id int
+	// Return the session to the pool.
+	returner func()
+	// DB connection.
+	db *sql.DB
+	// DB transaction history.
+	tx []*sql.Tx
+	// Closed indicator.
+	closed bool
+}
+
+//
+// Return the session to the pool.
+// After is has been returned, it MUST no longer be used.
+func (s *Session) Return() {
+	s.assertReserved()
+	s.returner()
+	s.returner = nil
+}
+
+//
+// Begin a transaction.
+func (s *Session) Begin() (tx *sql.Tx, err error) {
+	s.assertReserved()
+	tx, err = s.db.Begin()
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+	s.tx = append(s.tx, tx)
+
+	return
+}
+
+//
+// Assert reserved.
+// Ensure the session has been reserved and not
+// yet returned.
+func (s *Session) assertReserved() {
+	if s.returner == nil {
+		err := liberr.New(
+			"operation on returned session.")
+		panic(err)
+	}
+}
+
+//
+// Reset.
+// Ensure all transactions have been ended.
+func (s *Session) reset() {
+	for _, tx := range s.tx {
+		_ = tx.Rollback()
+	}
+
+	s.tx = nil
+}
+
+//
+// Session pool.
+type Pool struct {
+	// Journal.
+	journal *Journal
+	// All sessions.
+	sessions []*Session
+	// Next (free) sessions.
+	next struct {
+		writer chan *Session
+		reader chan *Session
+	}
+}
+
+//
+// Open the pool.
+// Create sessions with DB connections.
+// For sqlite3:
+//   Even with journal=WAL, nWriter must be (1) to
+//   prevent SQLITE_LOCKED error.
+func (p *Pool) Open(nWriter, nReader int, path string, journal *Journal) (err error) {
+	defer func() {
+		if err != nil {
+			_ = p.Close()
+		}
+	}()
+	p.journal = journal
+	total := nWriter + nReader
+	p.next.writer = make(chan *Session, nWriter)
+	p.next.reader = make(chan *Session, nReader)
+	for id := 0; id < total; id++ {
+		session := &Session{id: id}
+		session.db, err = sql.Open("sqlite3", path)
+		if err != nil {
+			return
+		}
+		pragma := []string{
+			"PRAGMA foreign_keys = ON",
+			"PRAGMA journal_mode = WAL",
+		}
+		for _, stmt := range pragma {
+			_, err = session.db.Exec(stmt)
+			if err != nil {
+				return
+			}
+		}
+		p.sessions = append(
+			p.sessions,
+			session)
+		if id < nWriter {
+			p.next.writer <- session
+		} else {
+			p.next.reader <- session
+		}
+	}
+
+	return
+}
+
+//
+// Close the pool.
+// Close DB connections.
+func (p *Pool) Close() (err error) {
+	for _, session := range p.sessions {
+		_ = session.db.Close()
+		session.closed = true
+	}
+
+	return
+}
+
+//
+// Get the next writer.
+// This may block until available.
+func (p *Pool) Writer() *Session {
+	return p.nextSession(p.next.writer)
+}
+
+//
+// Get the next reader.
+// This may block until available.
+func (p *Pool) Reader() *Session {
+	return p.nextSession(p.next.reader)
+}
+
+//
+// Get the next session.
+// This may block until available.
+func (p *Pool) nextSession(ch chan *Session) (session *Session) {
+	next := <-ch
+	session = &Session{
+		id: next.id,
+		db: next.db,
+		returner: func() {
+			session.reset()
+			ch <- next
+		},
+	}
+
+	return
+}


### PR DESCRIPTION
Improved model concurrency by using the `sqlite3` [WAL](https://sqlite.org/wal.html) journal.
The WAL journal supports concurrent read/write among separate DB connections.  As a result, the MUTEX used by the `model.Client` is no longer needed.  Instead, the `Client` sets the WAL pragma and maintains a _pool_ of DB `Session` which encapsulates a actual DB connection and provides DB connection reservation.  The pool dedicates a percentage to writing vs reading to prevent starvation of either operation.

The `model.Journal` no longer maintains the list of _staged_ events.  Its interface has slimmed down accordingly.
Instead, each transaction (Tx) contains the list of staged events which are reported (to the journal) in `Tx.Commit()`.

The unit tests file names needed to be unique to eliminate Disk I/O errors randomly occurring when the tests were run concurrently and stomping on each other's DB.
