### PR TITLE
Build snapshot before creating watch.

### DIFF
--- a/pkg/inventory/model/client.go
+++ b/pkg/inventory/model/client.go
@@ -306,14 +306,14 @@ func (r *Client) Watch(model Model, handler EventHandler) (w *Watch, err error) 
 				r.pool.Writer())
 		}
 	}
-	resumeWriting := func() {
+	unblockWriting := func() {
 		for _, w := range writers {
 			w.Return()
 		}
 	}
 	if options.Snapshot {
 		blockWriting()
-		defer resumeWriting()
+		defer unblockWriting()
 		reader := r.pool.Reader()
 		defer reader.Return()
 		table := Table{reader.db}

--- a/pkg/inventory/model/session.go
+++ b/pkg/inventory/model/session.go
@@ -79,6 +79,10 @@ type Pool struct {
 		writer chan *Session
 		reader chan *Session
 	}
+	// Number of writer.
+	nWriter int
+	// Number of reader.
+	nReader int
 }
 
 //
@@ -94,6 +98,8 @@ func (p *Pool) Open(nWriter, nReader int, path string, journal *Journal) (err er
 		}
 	}()
 	p.journal = journal
+	p.nWriter = nWriter
+	p.nReader = nReader
 	total := nWriter + nReader
 	p.next.writer = make(chan *Session, nWriter)
 	p.next.reader = make(chan *Session, nReader)
@@ -145,7 +151,6 @@ func (p *Pool) Writer() *Session {
 	return p.nextSession(p.next.writer)
 }
 
-//
 // Get the next reader.
 // This may block until available.
 func (p *Pool) Reader() *Session {


### PR DESCRIPTION
When a snapshot is requested:
- block writing
- list resources.
- start the watch.
- resume writing.

This will ensure: no events are missed and no duplicate events.