### PR TITLE
Adjust model logging. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Package:
     - Info(3):
       - database: lifecycle.
       - journal: journal and watch lifecycle.
+      - model: insert,update,delete.
     - Info(4):
-      - client: (db) transaction lifecycle;model CRUD.
+      - client: (db) transaction lifecycle;model get,list.
       - journal: event staging.
       - watch: lifecycle.
     - Info(5):

--- a/pkg/inventory/model/client.go
+++ b/pkg/inventory/model/client.go
@@ -501,7 +501,7 @@ func (r *Tx) Insert(model Model) (err error) {
 		return
 	}
 
-	r.log.V(4).Info(
+	r.log.V(3).Info(
 		"insert succeeded.",
 		"model",
 		Describe(model),
@@ -537,7 +537,7 @@ func (r *Tx) Update(model Model) (err error) {
 		return
 	}
 
-	r.log.V(4).Info(
+	r.log.V(3).Info(
 		"update succeeded.",
 		"model",
 		Describe(model),
@@ -573,7 +573,7 @@ func (r *Tx) Delete(model Model) (err error) {
 		return
 	}
 
-	r.log.V(4).Info(
+	r.log.V(3).Info(
 		"delete succeeded.",
 		"model",
 		Describe(model),

--- a/pkg/inventory/model/journal.go
+++ b/pkg/inventory/model/journal.go
@@ -356,11 +356,6 @@ func (r *Journal) Report(staged *fb.List) {
 	for _, w := range r.watches {
 		w.notify(staged.Iter())
 	}
-
-	r.log.V(3).Info(
-		"Events reported.",
-		"count",
-		staged.Len())
 }
 
 //


### PR DESCRIPTION
insert,update,delete moved to level=3.
This violates the guideline that level 4+ is when high-volume things are logged but seems useful to log when models are written at the lower level without all of the noise at level 4.