### PR TITLE
Transaction labels passed through on watch event.

### DIFF
--- a/pkg/inventory/model/journal.go
+++ b/pkg/inventory/model/journal.go
@@ -31,12 +31,26 @@ var (
 type Event struct {
 	// ID.
 	ID uint64
+	// Labels.
+	Labels []string
 	// The event subject.
 	Model Model
 	// The event action (created|updated|deleted).
 	Action uint8
 	// The updated model.
 	Updated Model
+}
+
+//
+// Get whether the event has the specified label.
+func (r *Event) HasLabel(label string) bool {
+	for _, l := range r.Labels {
+		if l == label {
+			return true
+		}
+	}
+
+	return false
 }
 
 //
@@ -77,6 +91,7 @@ func (r *Event) String() string {
 func (r *Event) append(list *fb.List) {
 	list.Append(Event{
 		ID:     r.ID,
+		Labels: r.Labels,
 		Action: r.Action,
 	})
 	list.Append(r.Model)

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -172,17 +172,22 @@ func (w *MutatingHandler) Created(e Event) {
 	tx, _ := w.DB.Begin()
 	tx.Get(e.Model)
 	e.Model.(*TestObject).Age++
-	tx.Update(e.Model)
-	tx.Commit()
+	_ = tx.Update(e.Model)
+	_ = tx.Commit()
 	w.created = append(w.created, e.Model.(*TestObject).ID)
 }
 
 func (w *MutatingHandler) Updated(e Event) {
-	tx, _ := w.DB.Begin()
+	label := "echo"
+	if e.HasLabel(label) {
+		// ignore the echo event.
+		return
+	}
+	tx, _ := w.DB.Begin(label)
 	tx.Get(e.Model)
 	e.Model.(*TestObject).Age++
-	tx.Update(e.Model)
-	tx.Commit()
+	_ = tx.Update(e.Model)
+	_ = tx.Commit()
 	w.updated = append(w.updated, e.Model.(*TestObject).ID)
 }
 
@@ -955,7 +960,7 @@ func TestMutatingWatch(t *testing.T) {
 
 	for {
 		time.Sleep(time.Millisecond * 10)
-		if len(handlerA.updated) > 100 {
+		if len(handlerA.updated) == N*2 {
 			break
 		}
 	}

--- a/pkg/inventory/web/handler.go
+++ b/pkg/inventory/web/handler.go
@@ -109,6 +109,8 @@ type ResourceBuilder func(model.Model) interface{}
 type Event struct {
 	// ID
 	ID uint64
+	// Labels.
+	Labels []string
 	// Action.
 	Action uint8
 	// Affected Resource.
@@ -284,6 +286,7 @@ func (r *WatchWriter) send(e model.Event) {
 	}
 	event := Event{
 		ID:     e.ID,
+		Labels: e.Labels,
 		Action: e.Action,
 	}
 	if e.Model != nil {


### PR DESCRIPTION
Add support for associating labels with transactions.
Transaction labels are passed through on watch `Event`.
The goal is to provide a method for handlers to ignore events based on labels.  A primary use case is an event handler that updates the model and needs to ignore the associated update _(echo)_ event.