### PR TITLE
Cascading Delete.

### DIFF
--- a/pkg/filebacked/iterator.go
+++ b/pkg/filebacked/iterator.go
@@ -6,6 +6,8 @@ package filebacked
 type Iterator interface {
 	// Number of items.
 	Len() int
+	// Reverse.
+	Reverse()
 	// Object at index.
 	At(index int) interface{}
 	// Object at index (with).
@@ -52,8 +54,30 @@ func (r *FbIterator) NextWith(object interface{}) (hasNext bool) {
 }
 
 //
+// Reverse the list.
+func (r *FbIterator) Reverse() {
+	in := r.index
+	if len(in) == 0 {
+		return
+	}
+	reversed := []int64{}
+	for i := len(in) - 1; i >= 0; i-- {
+		reversed = append(
+			reversed,
+			in[i])
+	}
+
+	r.index = reversed
+}
+
+//
 // Empty.
 type EmptyIterator struct {
+}
+
+//
+// Reverse.
+func (*EmptyIterator) Reverse() {
 }
 
 //

--- a/pkg/filebacked/list.go
+++ b/pkg/filebacked/list.go
@@ -84,7 +84,20 @@ type List struct {
 //
 // Append an object.
 func (l *List) Append(object interface{}) {
-	l.writer.Append(object)
+	switch object.(type) {
+	case Iterator:
+		itr := object.(Iterator)
+		for {
+			object, hasNext := itr.Next()
+			if hasNext {
+				l.writer.Append(object)
+			} else {
+				break
+			}
+		}
+	default:
+		l.writer.Append(object)
+	}
 }
 
 //

--- a/pkg/filebacked/list_test.go
+++ b/pkg/filebacked/list_test.go
@@ -162,6 +162,33 @@ func TestList(t *testing.T) {
 		g.Expect(user.ID).To(gomega.Equal(n / 2))
 	}
 	g.Expect(n).To(gomega.Equal(len(input)))
+
+	// Reverse
+	list = NewList()
+	for i := 0; i < 3; i++ {
+		list.Append(i)
+	}
+	itr = list.Iter()
+	itr.Reverse()
+	slice := []int{}
+	for {
+		n, hasNext := itr.Next()
+		if hasNext {
+			slice = append(slice, *n.(*int))
+		} else {
+			break
+		}
+	}
+	g.Expect(slice).To(gomega.Equal([]int{2, 1, 0}))
+
+	// Append iterator.
+	listA := NewList()
+	for i := 0; i < 3; i++ {
+		listA.Append(i)
+	}
+	listB := NewList()
+	listB.Append(listA.Iter())
+	g.Expect(listA.Len()).To(gomega.Equal(listB.Len()))
 }
 
 // Disabled by default.

--- a/pkg/inventory/container/collection.go
+++ b/pkg/inventory/container/collection.go
@@ -215,11 +215,11 @@ type DefaultShepherd struct {
 //
 // Model comparison.
 func (r *DefaultShepherd) Equals(mA, mB model.Model) bool {
-	fieldsA, _ := model.Table{}.Fields(mA)
-	fieldsB, _ := model.Table{}.Fields(mB)
-	for i := 0; i < len(fieldsA); i++ {
-		fA := fieldsA[i]
-		fB := fieldsB[i]
+	mdA, _ := model.Inspect(mA)
+	mdB, _ := model.Inspect(mB)
+	for i := 0; i < len(mdA.Fields); i++ {
+		fA := mdA.Fields[i]
+		fB := mdB.Fields[i]
 		if r.ignored(fA) {
 			continue
 		}
@@ -236,11 +236,11 @@ func (r *DefaultShepherd) Equals(mA, mB model.Model) bool {
 //
 // Update model A (stored) with model B (desired).
 func (r *DefaultShepherd) Update(mA, mB model.Model) {
-	fieldsA, _ := model.Table{}.Fields(mA)
-	fieldsB, _ := model.Table{}.Fields(mB)
-	for i := 0; i < len(fieldsA); i++ {
-		fA := fieldsA[i]
-		fB := fieldsB[i]
+	mdA, _ := model.Inspect(mA)
+	mdB, _ := model.Inspect(mB)
+	for i := 0; i < len(mdA.Fields); i++ {
+		fA := mdA.Fields[i]
+		fB := mdB.Fields[i]
 		if r.ignored(fA) {
 			continue
 		}

--- a/pkg/inventory/model/doc.go
+++ b/pkg/inventory/model/doc.go
@@ -11,8 +11,10 @@
 //       The generated primary key.
 //   `sql:"key"`
 //       The field is part of the natural key.
-//   `sql:"fk:T(F)"`
-//       Foreign key `T` = model type, `F` = model field.
+//   `sql:"fk(table flags...)"`
+//       Foreign key with optional flags:
+//         +must = referenced model must exist.
+//         +cascade = cascade delete.
 //   `sql:"unique(G)"`
 //       Unique index. `G` = unique-together fields.
 //   `sql:"index(G)"`

--- a/pkg/inventory/model/field.go
+++ b/pkg/inventory/model/field.go
@@ -1,0 +1,557 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	liberr "github.com/konveyor/controller/pkg/error"
+	"github.com/pkg/errors"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// SQL tag.
+	Tag = "sql"
+	// Max detail level.
+	MaxDetail = 9
+)
+
+// Default detail level.
+var DefaultDetail = 1
+
+//
+// Regex used for `pk(fields)` tags.
+var PkRegex = regexp.MustCompile(`(pk)((\()(.+)(\)))?`)
+
+//
+// Regex used for `unique(group)` tags.
+var UniqueRegex = regexp.MustCompile(`(unique)(\()(.+)(\))`)
+
+//
+// Regex used for `index(group)` tags.
+var IndexRegex = regexp.MustCompile(`(index)(\()(.+)(\))`)
+
+//
+// Regex used for `fk(table)` tags.
+var FkRegex = regexp.MustCompile(`(fk)(\()(.+)(\))`)
+
+//
+// Regex used for detail.
+var DetailRegex = regexp.MustCompile(`(d)([0-9]+)`)
+
+//
+// Model (struct) Field
+type Field struct {
+	// reflect.Type of the field.
+	Type *reflect.StructField
+	// reflect.Value of the field.
+	Value *reflect.Value
+	// Field name.
+	Name string
+	// SQL tag.
+	Tag string
+	// Staging (string) values.
+	string string
+	// Staging (int) values.
+	int int64
+	// Referenced as a parameter.
+	isParam bool
+}
+
+//
+// Validate.
+func (f *Field) Validate() error {
+	switch f.Value.Kind() {
+	case reflect.String:
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		if len(f.WithFields()) > 0 {
+			return liberr.Wrap(GenPkTypeErr)
+		}
+	default:
+		if f.Pk() {
+			return liberr.Wrap(PkTypeErr)
+		}
+	}
+	if f.Detail() > MaxDetail {
+		return liberr.Wrap(DetailErr)
+	}
+
+	return nil
+}
+
+//
+// Pull from model.
+// Populate the appropriate `staging` field using the
+// model field value.
+func (f *Field) Pull() interface{} {
+	switch f.Value.Kind() {
+	case reflect.Struct:
+		object := f.Value.Interface()
+		b, err := json.Marshal(&object)
+		if err == nil {
+			f.string = string(b)
+		}
+		return f.string
+	case reflect.Slice:
+		if !f.Value.IsNil() {
+			object := f.Value.Interface()
+			b, err := json.Marshal(&object)
+			if err == nil {
+				f.string = string(b)
+			}
+		} else {
+			f.string = "[]"
+		}
+		return f.string
+	case reflect.Map:
+		if !f.Value.IsNil() {
+			object := f.Value.Interface()
+			b, err := json.Marshal(&object)
+			if err == nil {
+				f.string = string(b)
+			}
+		} else {
+			f.string = "{}"
+		}
+		return f.string
+	case reflect.String:
+		f.string = f.Value.String()
+		return f.string
+	case reflect.Bool:
+		b := f.Value.Bool()
+		if b {
+			f.int = 1
+		}
+		return f.int
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		f.int = f.Value.Int()
+		if f.Incremented() {
+			f.int++
+		}
+		return f.int
+	}
+
+	return nil
+}
+
+//
+// Pointer used for Scan().
+func (f *Field) Ptr() interface{} {
+	switch f.Value.Kind() {
+	case reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		return &f.int
+	default:
+		return &f.string
+	}
+}
+
+//
+// Push to the model.
+// Set the model field value using the `staging` field.
+func (f *Field) Push() {
+	switch f.Value.Kind() {
+	case reflect.Struct:
+		if len(f.string) == 0 {
+			break
+		}
+		tv := reflect.New(f.Value.Type())
+		object := tv.Interface()
+		err := json.Unmarshal([]byte(f.string), &object)
+		if err == nil {
+			tv = reflect.ValueOf(object)
+			f.Value.Set(tv.Elem())
+		}
+	case reflect.Slice,
+		reflect.Map:
+		if len(f.string) == 0 {
+			break
+		}
+		tv := reflect.New(f.Value.Type())
+		object := tv.Interface()
+		err := json.Unmarshal([]byte(f.string), object)
+		if err == nil {
+			tv = reflect.ValueOf(object)
+			tv = reflect.Indirect(tv)
+			f.Value.Set(tv)
+		}
+	case reflect.String:
+		f.Value.SetString(f.string)
+	case reflect.Bool:
+		b := false
+		if f.int != 0 {
+			b = true
+		}
+		f.Value.SetBool(b)
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		f.Value.SetInt(f.int)
+	}
+}
+
+//
+// Column DDL.
+func (f *Field) DDL() string {
+	part := []string{
+		f.Name, // name
+		"",     // type
+		"",     // constraint
+	}
+	switch f.Value.Kind() {
+	case reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		part[1] = "INTEGER"
+	default:
+		part[1] = "TEXT"
+	}
+	if f.Pk() {
+		part[2] = "PRIMARY KEY"
+	} else {
+		part[2] = "NOT NULL"
+	}
+
+	return strings.Join(part, " ")
+}
+
+//
+// Get as SQL param.
+func (f *Field) Param() string {
+	f.isParam = true
+	return ":" + f.Name
+}
+
+//
+// Get whether field is the primary key.
+func (f *Field) Pk() (matched bool) {
+	for _, opt := range strings.Split(f.Tag, ",") {
+		m := PkRegex.FindStringSubmatch(opt)
+		if m != nil {
+			matched = true
+			break
+		}
+	}
+	return
+}
+
+//
+// Fields used to generate the primary key.
+// Map of lower-cased field names. May be empty
+// when generation is not enabled.
+func (f *Field) WithFields() (withFields map[string]bool) {
+	withFields = map[string]bool{}
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		m := PkRegex.FindStringSubmatch(opt)
+		if len(m) == 6 {
+			for _, name := range strings.Split(m[4], ";") {
+				name = strings.TrimSpace(name)
+				if len(name) > 0 {
+					name = strings.ToLower(name)
+					withFields[name] = true
+				}
+			}
+		}
+		break
+	}
+
+	return
+}
+
+//
+// Get whether field is mutable.
+// Only mutable fields will be updated.
+func (f *Field) Mutable() bool {
+	if f.Pk() || f.Key() || f.Virtual() {
+		return false
+	}
+
+	return !f.hasOpt("const")
+}
+
+//
+// Get whether field is a natural key.
+func (f *Field) Key() bool {
+	return f.hasOpt("key")
+}
+
+//
+// Get whether field is virtual.
+// A `virtual` field is read-only and managed
+// internally in the DB.
+func (f *Field) Virtual() bool {
+	return f.hasOpt("virtual")
+}
+
+//
+// Get whether the field is unique.
+func (f *Field) Unique() []string {
+	list := []string{}
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		m := UniqueRegex.FindStringSubmatch(opt)
+		if len(m) == 5 {
+			list = append(list, m[3])
+		}
+	}
+
+	return list
+}
+
+//
+// Get whether the field has non-unique index.
+func (f *Field) Index() []string {
+	list := []string{}
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		m := IndexRegex.FindStringSubmatch(opt)
+		if len(m) == 5 {
+			list = append(list, m[3])
+		}
+	}
+
+	return list
+}
+
+//
+// Get whether the field is a foreign key.
+// Format: fk(table flags..) where flags are optional.
+// Flags:
+//   +must = referenced model must exist.
+//   +cascade = cascade delete.
+func (f *Field) Fk() (fk *FK) {
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		m := FkRegex.FindStringSubmatch(opt)
+		if len(m) == 5 {
+			table := strings.Fields(m[3])
+			fk = &FK{
+				Table: table[0],
+				Owner: f,
+			}
+			if len(table) > 1 {
+				for _, flag := range table[1:] {
+					switch strings.TrimSpace(flag) {
+					case "+cascade":
+						fk.Cascade = true
+					case "+must":
+						fk.Must = true
+					default:
+						panic(
+							errors.Errorf(
+								"FK %s not supported",
+								flag))
+					}
+				}
+			}
+			break
+		}
+	}
+
+	return
+}
+
+//
+// Get whether field is auto-incremented.
+func (f *Field) Incremented() bool {
+	return f.hasOpt("incremented")
+}
+
+// Convert the specified `object` to a value
+// (type) appropriate for the field.
+func (f *Field) AsValue(object interface{}) (value interface{}, err error) {
+	val := reflect.ValueOf(object)
+	switch val.Kind() {
+	case reflect.Ptr:
+		val = val.Elem()
+	case reflect.Struct,
+		reflect.Slice,
+		reflect.Map:
+		err = liberr.Wrap(PredicateValueErr)
+		return
+	}
+	switch f.Value.Kind() {
+	case reflect.String:
+		switch val.Kind() {
+		case reflect.String:
+			value = val.String()
+		case reflect.Bool:
+			b := val.Bool()
+			value = strconv.FormatBool(b)
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			n := val.Int()
+			value = strconv.FormatInt(n, 0)
+		default:
+			err = liberr.Wrap(PredicateValueErr)
+		}
+	case reflect.Bool:
+		switch val.Kind() {
+		case reflect.String:
+			s := val.String()
+			b, pErr := strconv.ParseBool(s)
+			if pErr != nil {
+				err = liberr.Wrap(pErr)
+				return
+			}
+			value = b
+		case reflect.Bool:
+			value = val.Bool()
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			n := val.Int()
+			if n != 0 {
+				value = true
+			} else {
+				value = false
+			}
+		default:
+			err = liberr.Wrap(PredicateValueErr)
+		}
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		switch val.Kind() {
+		case reflect.String:
+			n, err := strconv.ParseInt(val.String(), 0, 64)
+			if err != nil {
+				err = liberr.Wrap(err)
+			}
+			value = n
+		case reflect.Bool:
+			if val.Bool() {
+				value = 1
+			} else {
+				value = 0
+			}
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			value = val.Int()
+		default:
+			err = liberr.Wrap(PredicateValueErr)
+		}
+	default:
+		err = liberr.Wrap(FieldTypeErr)
+	}
+
+	return
+}
+
+//
+// Get whether the field is `json` encoded.
+func (f *Field) Encoded() (encoded bool) {
+	switch f.Value.Kind() {
+	case reflect.Struct,
+		reflect.Slice,
+		reflect.Map:
+		encoded = true
+	}
+
+	return
+}
+
+//
+// Detail level.
+// Defaults:
+//   Key fields = 0.
+//        Other = DefaultDetail
+func (f *Field) Detail() (level int) {
+	level = DefaultDetail
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		m := DetailRegex.FindStringSubmatch(opt)
+		if len(m) == 3 {
+			level, _ = strconv.Atoi(m[2])
+			return
+		}
+	}
+	if f.Pk() || f.Key() {
+		level = 0
+		return
+	}
+
+	return
+}
+
+//
+// Match detail level.
+func (f *Field) MatchDetail(level int) bool {
+	return f.Detail() <= level
+}
+
+//
+// Get whether field has an option.
+func (f *Field) hasOpt(name string) bool {
+	for _, opt := range strings.Split(f.Tag, ",") {
+		opt = strings.TrimSpace(opt)
+		if opt == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+//
+// FK constraint.
+type FK struct {
+	// FK owner.
+	Owner *Field
+	// Target table name.
+	Table string
+	// Target field name.
+	Field string
+	// +must option enforced by constraint.
+	Must bool
+	// +cascade delete option.
+	Cascade bool
+}
+
+//
+// Get DDL.
+func (f *FK) DDL(field *Field) string {
+	return fmt.Sprintf(
+		"FOREIGN KEY (%s) REFERENCES %s (%s)",
+		field.Name,
+		f.Table,
+		f.Field)
+}
+
+//
+// Get whether the FK Needs an explicit index.
+// The `must` is implemented by a constraint which is
+// implicitly indexed by the DB.
+func (f *FK) needsIndex() bool {
+	return f.Cascade && !f.Must
+}

--- a/pkg/inventory/model/inspect.go
+++ b/pkg/inventory/model/inspect.go
@@ -1,0 +1,446 @@
+package model
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	fb "github.com/konveyor/controller/pkg/filebacked"
+	"reflect"
+	"strings"
+)
+
+func Inspect(model interface{}) (md *Definition, err error) {
+	md = &Definition{
+		model: model,
+	}
+	md.Kind = md.kind(model)
+	md.Fields, err = md.fields(model)
+	if err != nil {
+		return
+	}
+	err = md.validate()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+//
+// Model definition.
+type Definition struct {
+	Kind   string
+	Fields []*Field
+	model  interface{}
+}
+
+//
+// Get the mutable `Fields` for the model.
+func (r *Definition) MutableFields() []*Field {
+	list := []*Field{}
+	for _, f := range r.Fields {
+		if f.Mutable() {
+			list = append(list, f)
+		}
+	}
+
+	return list
+}
+
+//
+// Get the natural key `Fields` for the model.
+func (r *Definition) KeyFields() []*Field {
+	list := []*Field{}
+	for _, f := range r.Fields {
+		if f.Key() {
+			list = append(list, f)
+		}
+	}
+
+	return list
+}
+
+//
+// Get foreign keys for the model.
+func (r *Definition) Fks() []*FK {
+	list := []*FK{}
+	for _, f := range r.Fields {
+		fk := f.Fk()
+		if fk != nil {
+			list = append(list, fk)
+		}
+	}
+
+	return list
+}
+
+//
+// Get the non-virtual `Fields` for the model.
+func (r *Definition) RealFields(fields []*Field) []*Field {
+	list := []*Field{}
+	for _, f := range fields {
+		if !f.Virtual() {
+			list = append(list, f)
+		}
+	}
+
+	return list
+}
+
+//
+// Get the PK field.
+func (r *Definition) PkField() *Field {
+	for _, f := range r.Fields {
+		if f.Pk() {
+			return f
+		}
+	}
+
+	return nil
+}
+
+//
+// Field by name.
+func (r *Definition) Field(name string) *Field {
+	name = strings.ToLower(name)
+	for _, f := range r.Fields {
+		if strings.ToLower(f.Name) == name {
+			return f
+		}
+	}
+
+	return nil
+}
+
+//
+// Match (case-insensitive) by kind.
+func (r *Definition) IsKind(kind string) bool {
+	return strings.ToLower(kind) == strings.ToLower(r.Kind)
+}
+
+//
+// Get the table name for the model.
+func (r Definition) kind(model interface{}) string {
+	mt := reflect.TypeOf(model)
+	if mt.Kind() == reflect.Ptr {
+		mt = mt.Elem()
+	}
+
+	return mt.Name()
+}
+
+//
+// Validate the model.
+func (r *Definition) validate() (err error) {
+	for _, f := range r.Fields {
+		err = f.Validate()
+		if err != nil {
+			return
+		}
+	}
+	pk := r.PkField()
+	if pk == nil {
+		err = liberr.Wrap(MustHavePkErr)
+	}
+
+	return
+}
+
+//
+// Get the `Fields` for the model.
+func (r *Definition) fields(model interface{}) (fields []*Field, err error) {
+	mt := reflect.TypeOf(model)
+	mv := reflect.ValueOf(model)
+	if mt.Kind() == reflect.Ptr {
+		mt = mt.Elem()
+		mv = mv.Elem()
+	} else {
+		err = liberr.Wrap(MustBePtrErr)
+		return
+	}
+	if mv.Kind() != reflect.Struct {
+		err = liberr.Wrap(MustBeObjectErr)
+		return
+	}
+	for i := 0; i < mt.NumField(); i++ {
+		ft := mt.Field(i)
+		fv := mv.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
+		switch fv.Kind() {
+		case reflect.Struct:
+			sqlTag, found := ft.Tag.Lookup(Tag)
+			if found {
+				if sqlTag == "-" {
+					break
+				}
+				fields = append(
+					fields,
+					&Field{
+						Tag:   sqlTag,
+						Name:  ft.Name,
+						Value: &fv,
+						Type:  &ft,
+					})
+			} else {
+				nested, nErr := r.fields(fv.Addr().Interface())
+				if nErr != nil {
+					return
+				}
+				fields = append(fields, nested...)
+			}
+		case reflect.Slice,
+			reflect.Map,
+			reflect.String,
+			reflect.Bool,
+			reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			sqlTag, _ := ft.Tag.Lookup(Tag)
+			if sqlTag == "-" {
+				continue
+			}
+			fields = append(
+				fields,
+				&Field{
+					Tag:   sqlTag,
+					Name:  ft.Name,
+					Value: &fv,
+					Type:  &ft,
+				})
+		}
+	}
+
+	return
+}
+
+//
+// New model for kind.
+func (r *Definition) NewModel() (m interface{}) {
+	mt := reflect.TypeOf(r.model)
+	if mt.Kind() == reflect.Ptr {
+		mt = mt.Elem()
+	}
+	m = reflect.New(mt).Interface()
+	return
+}
+
+//
+// New data Model.
+func NewModel(models []interface{}) (dm *DataModel, err error) {
+	dm = &DataModel{
+		content: make(map[string]*Definition),
+	}
+	for _, m := range models {
+		var md *Definition
+		md, err = Inspect(m)
+		if err != nil {
+			return
+		}
+		dm.Add(md)
+	}
+
+	return
+}
+
+//
+// DataModel.
+// Map of definitions.
+type DataModel struct {
+	content map[string]*Definition
+}
+
+//
+// Add definition.
+func (r *DataModel) Add(md *Definition) {
+	key := strings.ToLower(md.Kind)
+	r.content[key] = md
+}
+
+//
+// Definitions.
+func (r *DataModel) Definitions() (list Definitions) {
+	list = Definitions{}
+	for _, md := range r.content {
+		list = append(list, md)
+	}
+
+	return
+}
+
+//
+// Build the DDL.
+func (r *DataModel) DDL() (list []string, err error) {
+	fkRelation := FkRelation{dm: r}
+	for _, md := range fkRelation.Definitions() {
+		var ddl []string
+		ddl, err = Table{}.DDL(md.model, r)
+		if err != nil {
+			return
+		}
+		list = append(list, ddl...)
+	}
+
+	return
+}
+
+//
+// Find by kind.
+func (r *DataModel) Find(kind string) (md *Definition, found bool) {
+	key := strings.ToLower(kind)
+	md, found = r.content[key]
+	return
+}
+
+//
+// Find with model.
+func (r *DataModel) FindWith(model interface{}) (md *Definition, found bool) {
+	kind := Definition{}.kind(model)
+	md, found = r.Find(kind)
+	return
+}
+
+//
+// Find models to be (cascade) deleted.
+func (r *DataModel) Deleted(tx *Tx, model interface{}) (cascaded fb.Iterator, err error) {
+	md, err := Inspect(model)
+	if err != nil {
+		return
+	}
+	relation := &FkRelation{dm: r}
+	cascaded, err = r.cascade(tx, relation, md)
+	if err != nil {
+		return
+	}
+	cascaded.Reverse()
+	return
+}
+
+//
+// Find models to be (cascade) deleted.
+func (r *DataModel) cascade(tx *Tx, relation *FkRelation, md *Definition) (cascaded fb.Iterator, err error) {
+	list := fb.NewList()
+	referencing := relation.Referencing(md)
+	pk := md.PkField()
+	pkID := pk.Pull()
+	for _, ref := range referencing {
+		if !ref.cascade {
+			continue
+		}
+		refModel := ref.md.NewModel()
+		var iter fb.Iterator
+		iter, err = tx.Find(
+			refModel,
+			ListOptions{
+				Predicate: Eq(
+					ref.field,
+					pkID),
+			})
+		if err != nil {
+			return
+		}
+		for {
+			var refMd *Definition
+			model, hasNext := iter.Next()
+			if !hasNext {
+				break
+			}
+			list.Append(model)
+			refMd, err = Inspect(model)
+			if err != nil {
+				return
+			}
+			var nIter fb.Iterator
+			nIter, err = r.cascade(tx, relation, refMd)
+			if err != nil {
+				return
+			}
+			list.Append(nIter)
+		}
+	}
+
+	cascaded = list.Iter()
+	list.Close()
+
+	return
+}
+
+//
+// Model definitions.
+type Definitions []*Definition
+
+//
+// Append model definition.
+func (r *Definitions) Append(md *Definition) {
+	*r = append(*r, md)
+}
+
+//
+// Push model definition.
+func (r *Definitions) Push(md *Definition) {
+	r.Append(md)
+}
+
+//
+// Head (first) model definition.
+// Returns: nil when empty.
+func (r *Definitions) Head(delete bool) (md *Definition) {
+	if len(*r) > 0 {
+		md = (*r)[0]
+	}
+	if delete {
+		*r = (*r)[1:]
+	}
+	return
+}
+
+//
+// Top (last) model definition.
+// Returns: nil when empty.
+func (r *Definitions) Top() (md *Definition) {
+	if len(*r) > 0 {
+		last := len(*r) - 1
+		md = (*r)[last]
+	}
+
+	return
+}
+
+//
+// Pop model definition.
+// Returns: nil when empty.
+func (r *Definitions) Pop() (md *Definition) {
+	if len(*r) > 0 {
+		last := len(*r) - 1
+		md = (*r)[last]
+		*r = (*r)[:last]
+	}
+
+	return
+}
+
+//
+// Delete model definition.
+func (r *Definitions) Delete(index int) {
+	_ = (*r)[index]
+	s := (*r)[:index]
+	if index < len(*r)-1 {
+		s = append(s, (*r)[index+1:]...)
+	}
+	*r = s
+}
+
+//
+// Reverse.
+func (r *Definitions) Reverse() {
+	if len(*r) == 0 {
+		return
+	}
+	reversed := []*Definition{}
+	for i := len(*r) - 1; i >= 0; i-- {
+		reversed = append(reversed, (*r)[i])
+	}
+	*r = reversed
+	return
+}

--- a/pkg/inventory/model/relation.go
+++ b/pkg/inventory/model/relation.go
@@ -1,0 +1,136 @@
+package model
+
+import liberr "github.com/konveyor/controller/pkg/error"
+
+//
+// FK relation.
+type FkRelation struct {
+	// Data model.
+	dm *DataModel
+	// Cached sorted definitions.
+	sorted Definitions
+}
+
+//
+// Build constraint DDL.
+func (r *FkRelation) DDL(md *Definition) (ddl []string, err error) {
+	for _, field := range md.Fields {
+		fk := field.Fk()
+		if fk == nil || !fk.Must {
+			continue
+		}
+		md, found := r.dm.Find(fk.Table)
+		if !found {
+			err = liberr.New(
+				"FK ref not found.",
+				"kind",
+				md.Kind,
+				"ref",
+				fk.Table)
+			return
+		}
+		pk := md.PkField()
+		fk.Field = pk.Name
+		ddl = append(ddl, fk.DDL(field))
+	}
+
+	return
+}
+
+//
+// Find model definitions that
+// reference the specified definition.
+func (r *FkRelation) Referencing(md *Definition) (list []*FkRef) {
+	list = []*FkRef{}
+	for _, refMd := range r.Definitions() {
+		for _, field := range refMd.Fields {
+			fk := field.Fk()
+			if fk == nil {
+				continue
+			}
+			if !md.IsKind(fk.Table) {
+				continue
+			}
+			list = append(
+				list,
+				&FkRef{
+					field:   field.Name,
+					cascade: fk.Cascade,
+					md:      refMd,
+				})
+		}
+	}
+
+	return
+}
+
+//
+// Model definitions dependency-sorted as needed to be created.
+func (r *FkRelation) Definitions() (list Definitions) {
+	r.sort()
+	list = r.sorted
+	return
+}
+
+//
+// Sort definitions as needed for creation.
+func (r *FkRelation) sort() {
+	if r.sorted != nil {
+		return
+	}
+	stack := Definitions{}
+	in := r.dm.Definitions()
+	for {
+		if len(stack) == 0 {
+			if len(in) > 0 {
+				next := in.Head(true)
+				stack.Push(next)
+			} else {
+				break
+			}
+		}
+		md := stack.Top()
+		refMd, found := r.nextRef(&in, md)
+		if found {
+			stack.Push(refMd)
+		} else {
+			r.sorted = append(
+				r.sorted,
+				stack.Pop())
+		}
+	}
+	r.sorted.Reverse()
+	return
+}
+
+//
+// Find next model definition that references the
+// specified definition. The found definition is removed
+// from the candidate (in) list.
+func (r *FkRelation) nextRef(in *Definitions, md *Definition) (ref *Definition, found bool) {
+	for i, refMd := range *in {
+		for _, field := range refMd.Fields {
+			fk := field.Fk()
+			if fk == nil || !md.IsKind(fk.Table) {
+				continue
+			}
+			in.Delete(i)
+			found = true
+			ref = refMd
+			return
+		}
+	}
+
+	return
+}
+
+//
+// FK reference.
+type FkRef struct {
+	// Field name.
+	field string
+	// Cascade
+	cascade bool
+	// Model definition.
+	md *Definition
+}


### PR DESCRIPTION
Better support cascade delete based on foreign keys.
This needs to be done by the model layer instead of in the DB using _ON CASCADE DELETE_ foreign key constraints to support event generation.

This PR:
- Refactor `Table` object and split out the model _inspection_ functionality (which includes `Field`) into a _new_ model `Definition` object.
- Add _new_ `DataModel` which is the collective representation of all models.
- Add _new_ `FkRelation` object to model foreign key relationships and provide functionality needed to support cascade delete based on FK relationships. Find dependent models.
- Enhanced FK tag: `fk(`_table_, _+must +cascade_`)` makes enforcement (with constraint) and cascade delete optional.
- Update _filebacked_ package
  - Update List.Append() to append `Iterator`.
  - Add Iterator.Reverse()   
