### PR TITLE
model.DefaultDetail should be 0.

### DIFF
--- a/pkg/inventory/model/field.go
+++ b/pkg/inventory/model/field.go
@@ -18,8 +18,14 @@ const (
 	MaxDetail = 9
 )
 
-// Default detail level.
-var DefaultDetail = 1
+// The default (field) detail level when listing models.
+// Applications using custom detail levels
+// must adjust to highest level used.
+// Example:
+//   func init() {
+//     model.DefaultDetail = 2
+//   }
+var DefaultDetail = 0
 
 //
 // Regex used for `pk(fields)` tags.

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -10,8 +10,10 @@ import (
 	"time"
 )
 
+//
+// Adjust default.
 func init() {
-	DefaultDetail = MaxDetail
+	DefaultDetail = 5
 }
 
 type TestEncoded struct {


### PR DESCRIPTION
After working with this for a bit, It seems more intuitive for the model layer is to select/populate **all** fields by default.  I think only selecting/populating the _key_ fields would be unexpected.
Applications using the _lib_ should add adjust as needed:
```
func init() {
    libmodel.DefaultDetail = 3
}
```
when working with _custom_ detail levels.