### PR TITLE
Support update predicate.

### DIFF
--- a/pkg/inventory/model/client.go
+++ b/pkg/inventory/model/client.go
@@ -32,7 +32,7 @@ type DB interface {
 	// Insert a model.
 	Insert(Model) error
 	// Update a model.
-	Update(Model) error
+	Update(Model, ...Predicate) error
 	// Delete a model.
 	Delete(Model) error
 	// Watch a model collection.
@@ -259,7 +259,7 @@ func (r *Client) Insert(model Model) (err error) {
 //
 // Update the model.
 // Delegated to Tx.Update().
-func (r *Client) Update(model Model) (err error) {
+func (r *Client) Update(model Model, predicate ...Predicate) (err error) {
 	tx, err := r.Begin()
 	if err != nil {
 		return
@@ -271,7 +271,7 @@ func (r *Client) Update(model Model) (err error) {
 			_ = tx.End()
 		}
 	}()
-	err = tx.Update(model)
+	err = tx.Update(model, predicate...)
 
 	return
 }
@@ -520,7 +520,7 @@ func (r *Tx) Insert(model Model) (err error) {
 
 //
 // Update the model.
-func (r *Tx) Update(model Model) (err error) {
+func (r *Tx) Update(model Model, predicate ...Predicate) (err error) {
 	mark := time.Now()
 	current := model
 	current = Clone(model)
@@ -528,7 +528,7 @@ func (r *Tx) Update(model Model) (err error) {
 	if err != nil {
 		return
 	}
-	err = Table{r.real}.Update(model)
+	err = Table{r.real}.Update(model, predicate...)
 	if err != nil {
 		return
 	}

--- a/pkg/inventory/model/model_test.go
+++ b/pkg/inventory/model/model_test.go
@@ -375,6 +375,12 @@ func TestCRUD(t *testing.T) {
 	err = DB.Update(objA)
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(objA.Rev).To(gomega.Equal(2))
+	// Update with predicate.
+	objA.Name = "Fred"
+	objA.Age = 14
+	err = DB.Update(objA, Eq("Age", 21))
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(objA.Rev).To(gomega.Equal(3))
 	// Get
 	objB = &TestObject{ID: objA.ID}
 	err = DB.Get(objB)

--- a/pkg/inventory/model/predicate.go
+++ b/pkg/inventory/model/predicate.go
@@ -105,7 +105,7 @@ func Match(labels Labels) *LabelPredicate {
 // List predicate.
 type Predicate interface {
 	// Build the predicate.
-	Build(*ListOptions) error
+	Build(*FilterOptions) error
 	// Get the SQL expression.
 	Expr() string
 }
@@ -142,7 +142,7 @@ func (p *SimplePredicate) field(name string, fields []*Field) (*Field, bool) {
 
 //
 // Build.
-func (p *SimplePredicate) build(operator string, options *ListOptions) error {
+func (p *SimplePredicate) build(operator string, options *FilterOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
 		return liberr.Wrap(PredicateRefErr)
@@ -184,7 +184,7 @@ type EqPredicate struct {
 
 //
 // Build.
-func (p *EqPredicate) Build(options *ListOptions) error {
+func (p *EqPredicate) Build(options *FilterOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
 		return liberr.Wrap(PredicateRefErr)
@@ -231,7 +231,7 @@ type NeqPredicate struct {
 
 //
 // Build.
-func (p *NeqPredicate) Build(options *ListOptions) error {
+func (p *NeqPredicate) Build(options *FilterOptions) error {
 	return p.build("!=", options)
 }
 
@@ -249,7 +249,7 @@ type GtPredicate struct {
 
 //
 // Build.
-func (p *GtPredicate) Build(options *ListOptions) error {
+func (p *GtPredicate) Build(options *FilterOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
 		return liberr.Wrap(PredicateRefErr)
@@ -283,7 +283,7 @@ type LtPredicate struct {
 
 //
 // Build.
-func (p *LtPredicate) Build(options *ListOptions) error {
+func (p *LtPredicate) Build(options *FilterOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
 		return liberr.Wrap(PredicateRefErr)
@@ -324,7 +324,7 @@ type AndPredicate struct {
 
 //
 // Build.
-func (p *AndPredicate) Build(options *ListOptions) error {
+func (p *AndPredicate) Build(options *FilterOptions) error {
 	for _, p := range p.Predicates {
 		err := p.Build(options)
 		if err != nil {
@@ -356,7 +356,7 @@ type OrPredicate struct {
 
 //
 // Build.
-func (p *OrPredicate) Build(options *ListOptions) error {
+func (p *OrPredicate) Build(options *FilterOptions) error {
 	for _, p := range p.Predicates {
 		err := p.Build(options)
 		if err != nil {
@@ -386,7 +386,7 @@ type LabelPredicate struct {
 	// Labels
 	Labels
 	// List options.
-	options *ListOptions
+	options *FilterOptions
 	// Parent PK field name.
 	pk *Field
 	// SQL expression.
@@ -395,7 +395,7 @@ type LabelPredicate struct {
 
 //
 // Build.
-func (p *LabelPredicate) Build(options *ListOptions) error {
+func (p *LabelPredicate) Build(options *FilterOptions) error {
 	p.options = options
 	for _, f := range options.fields {
 		if f.Pk() {

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -67,6 +67,9 @@ SET
 {{ end -}}
 WHERE
 {{ .Pk.Name }} = {{ .Pk.Param }}
+{{ if .Predicate -}}
+AND {{ .Predicate.Expr }}
+{{ end -}}
 ;
 `
 
@@ -358,17 +361,22 @@ func (t Table) Insert(model interface{}) (err error) {
 //
 // Update the model in the DB.
 // Expects the primary key (PK) to be set.
-func (t Table) Update(model interface{}) (err error) {
+func (t Table) Update(model interface{}, predicate ...Predicate) (err error) {
 	md, err := Inspect(model)
 	if err != nil {
 		return
 	}
 	t.EnsurePk(md)
-	stmt, err := t.updateSQL(md)
+	options := &ListOptions{}
+	for _, p := range predicate {
+		options.Predicate = p
+		break
+	}
+	stmt, err := t.updateSQL(md, options)
 	if err != nil {
 		return
 	}
-	params := t.Params(md)
+	params := append(t.Params(md), options.Params()...)
 	r, err := t.DB.Exec(stmt, params...)
 	if err != nil {
 		err = liberr.Wrap(
@@ -775,20 +783,25 @@ func (t Table) insertSQL(md *Definition) (sql string, err error) {
 
 //
 // Build model update SQL.
-func (t Table) updateSQL(md *Definition) (sql string, err error) {
+func (t Table) updateSQL(md *Definition, options *FilterOptions) (sql string, err error) {
 	tpl := template.New("")
 	tpl, err = tpl.Parse(UpdateSQL)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
+	err = options.Build(md)
+	if err != nil {
+		return
+	}
 	bfr := &bytes.Buffer{}
 	err = tpl.Execute(
 		bfr,
 		TmplData{
-			Table:  md.Kind,
-			Fields: md.MutableFields(),
-			Pk:     md.PkField(),
+			Table:   md.Kind,
+			Fields:  md.MutableFields(),
+			Options: options,
+			Pk:      md.PkField(),
 		})
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -887,7 +900,7 @@ func (t Table) listSQL(md *Definition, options *ListOptions) (sql string, err er
 
 //
 // Build model count SQL.
-func (t Table) countSQL(md *Definition, options *ListOptions) (sql string, err error) {
+func (t Table) countSQL(md *Definition, options *FilterOptions) (sql string, err error) {
 	tpl := template.New("")
 	tpl, err = tpl.Parse(ListSQL)
 	if err != nil {
@@ -954,8 +967,8 @@ type TmplData struct {
 	Keys []*Field
 	// Primary key.
 	Pk *Field
-	// List options.
-	Options *ListOptions
+	// Filter options.
+	Options *FilterOptions
 	// Count
 	Count bool
 }
@@ -979,8 +992,8 @@ func (t TmplData) Sort() []int {
 }
 
 //
-// List options.
-type ListOptions struct {
+// FilterOptions options.
+type FilterOptions struct {
 	// Pagination.
 	Page *Page
 	// Sort by field position.
@@ -1002,7 +1015,7 @@ type ListOptions struct {
 
 //
 // Validate options.
-func (l *ListOptions) Build(md *Definition) (err error) {
+func (l *FilterOptions) Build(md *Definition) (err error) {
 	l.table = md.Kind
 	l.fields = md.Fields
 	if l.Predicate != nil {
@@ -1015,7 +1028,7 @@ func (l *ListOptions) Build(md *Definition) (err error) {
 //
 // Get an appropriate parameter name.
 // Builds a parameter and adds it to the options.param list.
-func (l *ListOptions) Param(name string, value interface{}) (p string) {
+func (l *FilterOptions) Param(name string, value interface{}) (p string) {
 	name = fmt.Sprintf("%s%d", name, len(l.params))
 	l.params = append(l.params, sql.Named(name, value))
 	p = ":" + name
@@ -1024,7 +1037,7 @@ func (l *ListOptions) Param(name string, value interface{}) (p string) {
 
 //
 // Fields filtered by detail level.
-func (l *ListOptions) Fields() (filtered []*Field) {
+func (l *FilterOptions) Fields() (filtered []*Field) {
 	for _, f := range l.fields {
 		if f.MatchDetail(l.Detail) {
 			filtered = append(filtered, f)
@@ -1036,6 +1049,10 @@ func (l *ListOptions) Fields() (filtered []*Field) {
 
 //
 // Get params referenced by the predicate.
-func (l *ListOptions) Params() []interface{} {
+func (l *FilterOptions) Params() []interface{} {
 	return l.params
 }
+
+//
+// List options
+type ListOptions = FilterOptions

--- a/pkg/inventory/model/table.go
+++ b/pkg/inventory/model/table.go
@@ -368,9 +368,8 @@ func (t Table) Update(model interface{}, predicate ...Predicate) (err error) {
 	}
 	t.EnsurePk(md)
 	options := &ListOptions{}
-	for _, p := range predicate {
-		options.Predicate = p
-		break
+	if len(predicate) > 0 {
+		options.Predicate = And(predicate...)
 	}
 	stmt, err := t.updateSQL(md, options)
 	if err != nil {


### PR DESCRIPTION
Add support for update with (optional) predicate.  The predicate is in addition to the PK match.

Eg:
`db.Update(model, Eq("Revision", 1))`